### PR TITLE
Add language switcher and i18n support

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { ThemeProvider, useTheme } from './contexts/ThemeContext';
+import { LanguageProvider, useLanguage } from './contexts/LanguageContext';
 import GlobalStyles from './styles/GlobalStyles';
 
 // Import Page Components
@@ -23,11 +24,12 @@ import SuccessPage_EN from './components/SuccessPage_EN';
 const AppContent = () => {
   const [navigation, setNavigation] = useState({ page: 'languageSelection', flow: null });
   const { theme } = useTheme();
+  const { language } = useLanguage();
 
   useEffect(() => {
-    document.body.dir = 'ltr';
+    document.body.dir = language === 'ar' ? 'rtl' : 'ltr';
     document.body.setAttribute('data-theme', theme);
-  }, [theme]);
+  }, [theme, language]);
 
   const handleNavigation = (page) => {
     let currentFlow = navigation.flow;
@@ -83,9 +85,11 @@ const AppContent = () => {
 
 export default function App() {
     return (
-        <ThemeProvider>
-            <GlobalStyles />
-            <AppContent />
-        </ThemeProvider>
+        <LanguageProvider>
+            <ThemeProvider>
+                <GlobalStyles />
+                <AppContent />
+            </ThemeProvider>
+        </LanguageProvider>
     );
 }

--- a/src/components/CompaniesDocsPage_EN.js
+++ b/src/components/CompaniesDocsPage_EN.js
@@ -1,19 +1,28 @@
 import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
 import { UploadIcon } from './common/Icons';
+import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const CompaniesDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
+    const { language } = useLanguage();
     return (
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                 <button onClick={() => onNavigate(backPage)} className="btn-back">
+                <div style={{ display: 'flex', gap: '10px' }}>
+                    <LanguageSwitcher />
+                    <ThemeSwitcher />
+                </div>
+                <button onClick={() => onNavigate(backPage)} className="btn-back">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-                    <span>Back</span>
+                    <span>{t('back', language)}</span>
                 </button>
             </header>
             <main className="form-main">
-                <h2 className="form-title">Required Documents</h2>
+                <h2 className="form-title">{t('requiredDocs', language)}</h2>
                 <div className="docs-grid">
                     <div className="upload-box"><p>Bank statement for the last months (if any)</p><div className="upload-placeholder"><UploadIcon /></div></div>
                     <div className="upload-box"><p>Tax Card or Certificate</p><div className="upload-placeholder"><UploadIcon /></div></div>
@@ -23,7 +32,7 @@ const CompaniesDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
                     <div className="upload-box"><p>Photos of National ID or Passport for authorized signatories</p><div className="multi-upload-placeholders"><div className="upload-placeholder"><UploadIcon /></div><div className="upload-placeholder"><UploadIcon /></div><div className="upload-placeholder"><UploadIcon /></div></div></div>
                     <div className="upload-box"><p>Recent personal photos for authorized signatories</p><div className="multi-upload-placeholders"><div className="upload-placeholder"><UploadIcon /></div><div className="upload-placeholder"><UploadIcon /></div><div className="upload-placeholder"><UploadIcon /></div></div></div>
                 </div>
-                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>Next</button></div>
+                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>
             </main>
         </div>
     );

--- a/src/components/CompanyContactPage_EN.js
+++ b/src/components/CompanyContactPage_EN.js
@@ -1,14 +1,23 @@
 import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
+import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const CompanyContactPage_EN = ({ onNavigate, backPage, nextPage }) => {
+    const { language } = useLanguage();
     return (
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
+                <div style={{ display: 'flex', gap: '10px' }}>
+                    <LanguageSwitcher />
+                    <ThemeSwitcher />
+                </div>
                  <button onClick={() => onNavigate(backPage)} className="btn-back">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-                    <span>Back</span>
+                    <span>{t('back', language)}</span>
                 </button>
             </header>
             <main className="form-main">
@@ -33,7 +42,7 @@ const CompanyContactPage_EN = ({ onNavigate, backPage, nextPage }) => {
                     </div>
                 </form>
                 <div className="form-actions">
-                    <button className="btn-next" onClick={() => onNavigate(nextPage)}>Next</button>
+                    <button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button>
                 </div>
             </main>
         </div>

--- a/src/components/CompanyInfoPage_EN.js
+++ b/src/components/CompanyInfoPage_EN.js
@@ -2,15 +2,24 @@
 import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
 import { CalendarIcon } from './common/Icons';
+import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const CompanyInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
+    const { language } = useLanguage();
     return (
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
+                <div style={{ display: 'flex', gap: '10px' }}>
+                    <LanguageSwitcher />
+                    <ThemeSwitcher />
+                </div>
                  <button onClick={() => onNavigate(backPage)} className="btn-back">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-                    <span>Back</span>
+                    <span>{t('back', language)}</span>
                 </button>
             </header>
             <main className="form-main">
@@ -34,7 +43,7 @@ const CompanyInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
                         </div>
                     </div>
                 </form>
-                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>Next</button></div>
+                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>
             </main>
         </div>
     );

--- a/src/components/ContactInfoPage_EN.js
+++ b/src/components/ContactInfoPage_EN.js
@@ -1,15 +1,24 @@
 
 import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
+import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const ContactInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
+    const { language } = useLanguage();
     return (
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                 <button onClick={() => onNavigate(backPage)} className="btn-back">
+                <div style={{ display: 'flex', gap: '10px' }}>
+                    <LanguageSwitcher />
+                    <ThemeSwitcher />
+                </div>
+                <button onClick={() => onNavigate(backPage)} className="btn-back">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-                    <span>Back</span>
+                    <span>{t('back', language)}</span>
                 </button>
             </header>
             <main className="form-main">
@@ -26,7 +35,7 @@ const ContactInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
                         <div className="form-group"><input type="email" className="form-input" placeholder="Email Address" /></div>
                     </div>
                 </form>
-                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>Next</button></div>
+                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>
             </main>
         </div>
     );

--- a/src/components/FinancialInfoPage_EN.js
+++ b/src/components/FinancialInfoPage_EN.js
@@ -1,15 +1,24 @@
 
 import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
+import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const FinancialInfoPage_EN = ({ onNavigate, backPage }) => {
+    const { language } = useLanguage();
     return (
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
+                <div style={{ display: 'flex', gap: '10px' }}>
+                    <LanguageSwitcher />
+                    <ThemeSwitcher />
+                </div>
                  <button onClick={() => onNavigate(backPage)} className="btn-back">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-                    <span>Back</span>
+                    <span>{t('back', language)}</span>
                 </button>
             </header>
             <main className="form-main">
@@ -47,7 +56,7 @@ const FinancialInfoPage_EN = ({ onNavigate, backPage }) => {
                             <span>I agree to the <a href="#">Terms and Conditions</a>.</span>
                         </label>
                     </div>
-                    <button className="btn-next" onClick={() => onNavigate('success')}>Submit Request</button>
+                    <button className="btn-next" onClick={() => onNavigate('success')}>{t('submitRequest', language)}</button>
                 </div>
             </main>
         </div>

--- a/src/components/LandingPage_EN.js
+++ b/src/components/LandingPage_EN.js
@@ -1,22 +1,31 @@
 import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
 import { OpenAccountIcon, CompleteAccountIcon } from './common/Icons';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import ThemeSwitcher from './common/ThemeSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const LandingPage_EN = ({ onNavigate }) => {
+  const { language } = useLanguage();
   return (
     <div className="landing-container">
+      <div style={{ position: 'absolute', top: 20, right: 20, display: 'flex', gap: '10px' }}>
+        <LanguageSwitcher />
+        <ThemeSwitcher />
+      </div>
       <div className="content-wrapper">
         <img src={LOGO_WHITE} alt="Bank Logo" className="landing-logo" />
-        <h1 className="landing-title">Daman Islamic Bank</h1>
-        <p className="landing-subtitle">Your gateway to modern banking services</p>
+        <h1 className="landing-title">{t('welcomeTitle', language)}</h1>
+        <p className="landing-subtitle">{t('welcomeSub', language)}</p>
         <div className="landing-buttons-container">
           <button onClick={() => onNavigate('selectUser')}>
             <OpenAccountIcon />
-            <span>Open a New Account</span>
+            <span>{t('openAccount', language)}</span>
           </button>
           <button onClick={() => onNavigate('selectUser')} className="btn-secondary">
             <CompleteAccountIcon />
-            <span>Complete Account Opening</span>
+            <span>{t('completeAccount', language)}</span>
           </button>
         </div>
       </div>

--- a/src/components/LanguageSelectionPage.js
+++ b/src/components/LanguageSelectionPage.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
+import { t } from '../i18n';
 
 const LanguageSelectionPage = ({ onNavigate }) => {
     return (
@@ -7,7 +8,7 @@ const LanguageSelectionPage = ({ onNavigate }) => {
             <div className="lang-selection-box">
                 <img src={LOGO_WHITE} alt="Daman Islamic Bank" className="lang-logo" />
                 <div className="lang-buttons-container">
-                    <button className="lang-btn" onClick={() => onNavigate('landing')}>English</button>
+                    <button className="lang-btn" onClick={() => onNavigate('landing')}>{t('english')}</button>
                 </div>
             </div>
         </div>

--- a/src/components/LegalRepInfoPage_EN.js
+++ b/src/components/LegalRepInfoPage_EN.js
@@ -2,15 +2,24 @@
 import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
 import { CalendarIcon } from './common/Icons';
+import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const LegalRepInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
+    const { language } = useLanguage();
     return (
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
+                <div style={{ display: 'flex', gap: '10px' }}>
+                    <LanguageSwitcher />
+                    <ThemeSwitcher />
+                </div>
                  <button onClick={() => onNavigate(backPage)} className="btn-back">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-                    <span>Back</span>
+                    <span>{t('back', language)}</span>
                 </button>
             </header>
             <main className="form-main">
@@ -52,7 +61,7 @@ const LegalRepInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
                     </div>
                 </form>
                 <div className="form-actions">
-                    <button className="btn-next" onClick={() => onNavigate(nextPage)}>Next</button>
+                    <button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button>
                 </div>
             </main>
         </div>

--- a/src/components/PersonalInfoPage_EN.js
+++ b/src/components/PersonalInfoPage_EN.js
@@ -2,15 +2,24 @@
 import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
 import { CalendarIcon } from './common/Icons';
+import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const PersonalInfoPage_EN = ({ onNavigate, backPage }) => {
+    const { language } = useLanguage();
     return (
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
+                <div style={{ display: 'flex', gap: '10px' }}>
+                    <LanguageSwitcher />
+                    <ThemeSwitcher />
+                </div>
                  <button onClick={() => onNavigate(backPage)} className="btn-back">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-                    <span>Back</span>
+                    <span>{t('back', language)}</span>
                 </button>
             </header>
             <main className="form-main">
@@ -33,8 +42,8 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage }) => {
                         <label className="agreement-item"><div className="custom-checkbox"><input type="checkbox" defaultChecked/><span className="checkmark"></span></div><span>I certify that all data entered is correct.</span></label>
                         <label className="agreement-item"><div className="custom-checkbox"><input type="checkbox" /><span className="checkmark"></span></div><span>I agree to the <a href="#">Terms and Conditions</a>.</span></label>
                     </div>
-                    <button className="btn-next" onClick={() => onNavigate('success')}>Submit Request</button>
-                </div>
+                    <button className="btn-next" onClick={() => onNavigate('success')}>{t('submitRequest', language)}</button>
+            </div>
             </main>
         </div>
     );

--- a/src/components/SelectUserPage_EN.js
+++ b/src/components/SelectUserPage_EN.js
@@ -2,7 +2,10 @@
 import React, { useEffect } from 'react';
 import { LOGO_COLOR } from '../assets/imagePaths';
 import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
 import { PersonalIcon, GuaranteedIcon, BusinessmenIcon, CompaniesIcon } from './common/Icons';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const SelectUserPage_EN = ({ onNavigate }) => {
   useEffect(() => {
@@ -27,11 +30,16 @@ const SelectUserPage_EN = ({ onNavigate }) => {
     };
   }, []);
 
+  const { language } = useLanguage();
+
   return (
     <div className="app-container">
       <header className="header">
         <img src={LOGO_COLOR} alt="Bank Logo" className="logo" />
-        <ThemeSwitcher />
+        <div style={{ display: 'flex', gap: '10px' }}>
+          <LanguageSwitcher />
+          <ThemeSwitcher />
+        </div>
       </header>
       <main className="main">
         <div className="background">
@@ -39,11 +47,11 @@ const SelectUserPage_EN = ({ onNavigate }) => {
           <div className="overlay"></div>
         </div>
         <div className="menu-card tilt-effect">
-          <h2>Select Service Type</h2>
-          <button onClick={() => onNavigate('personalDocs')}><PersonalIcon /><span>Personal</span></button>
-          <button onClick={() => onNavigate('guaranteedDocs')}><GuaranteedIcon /><span>Guaranteed</span></button>
-          <button onClick={() => onNavigate('businessmenDocs')}><BusinessmenIcon /><span>Businessmen</span></button>
-          <button onClick={() => onNavigate('companiesDocs')}><CompaniesIcon /><span>Companies</span></button>
+          <h2>{t('selectService', language)}</h2>
+          <button onClick={() => onNavigate('personalDocs')}><PersonalIcon /><span>{t('personal', language)}</span></button>
+          <button onClick={() => onNavigate('guaranteedDocs')}><GuaranteedIcon /><span>{t('guaranteed', language)}</span></button>
+          <button onClick={() => onNavigate('businessmenDocs')}><BusinessmenIcon /><span>{t('businessmen', language)}</span></button>
+          <button onClick={() => onNavigate('companiesDocs')}><CompaniesIcon /><span>{t('companies', language)}</span></button>
         </div>
       </main>
     </div>

--- a/src/components/SimpleDocsPage_EN.js
+++ b/src/components/SimpleDocsPage_EN.js
@@ -3,26 +3,34 @@ import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
 import { UploadIcon } from './common/Icons';
 import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
+    const { language } = useLanguage();
     return (
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                 <button onClick={() => onNavigate(backPage)} className="btn-back">
+                <div style={{ display: 'flex', gap: '10px' }}>
+                    <LanguageSwitcher />
+                    <ThemeSwitcher />
+                </div>
+                <button onClick={() => onNavigate(backPage)} className="btn-back">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-                    <span>Back</span>
+                    <span>{t('back', language)}</span>
                 </button>
             </header>
             <main className="form-main">
-                <h2 className="form-title">{title}</h2>
+                <h2 className="form-title">{t(title.toLowerCase(), language)}</h2>
                 <div className="docs-grid">
                     <div className="upload-box"><p>Approved National ID</p><div className="upload-placeholder"><UploadIcon /></div></div>
                     <div className="upload-box"><p>Passport Photo</p><div className="upload-placeholder"><UploadIcon /></div></div>
                     <div className="upload-box"><p>Account Opening Letter from Employer</p><div className="upload-placeholder"><UploadIcon /></div></div>
                     <div className="upload-box"><p>Recent Personal Photo</p><div className="upload-placeholder"><UploadIcon /></div></div>
                 </div>
-                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>Next</button></div>
+                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>
             </main>
         </div>
     );

--- a/src/components/SuccessPage_EN.js
+++ b/src/components/SuccessPage_EN.js
@@ -1,13 +1,22 @@
 import React from 'react';
 import { SuccessIcon } from './common/Icons';
+import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const SuccessPage_EN = ({ onNavigate }) => {
+    const { language } = useLanguage();
     return (
         <div className="success-page">
+            <div style={{ position: 'absolute', top: 20, right: 20, display: 'flex', gap: '10px' }}>
+                <LanguageSwitcher />
+                <ThemeSwitcher />
+            </div>
             <SuccessIcon />
-            <h1 className="success-title">Success!</h1>
-            <p className="success-message">Your request has been submitted successfully. We will contact you shortly.</p>
-            <button className="btn-next" onClick={() => onNavigate('languageSelection')}>Back to Home</button>
+            <h1 className="success-title">{t('successTitle', language)}</h1>
+            <p className="success-message">{t('successMsg', language)}</p>
+            <button className="btn-next" onClick={() => onNavigate('languageSelection')}>{t('backToHome', language)}</button>
         </div>
     );
 };

--- a/src/components/WorkInfoPage_EN.js
+++ b/src/components/WorkInfoPage_EN.js
@@ -1,15 +1,24 @@
 
 import React from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
+import ThemeSwitcher from './common/ThemeSwitcher';
+import LanguageSwitcher from './common/LanguageSwitcher';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const WorkInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
+    const { language } = useLanguage();
     return (
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
+                <div style={{ display: 'flex', gap: '10px' }}>
+                    <LanguageSwitcher />
+                    <ThemeSwitcher />
+                </div>
                  <button onClick={() => onNavigate(backPage)} className="btn-back">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-                    <span>Back</span>
+                    <span>{t('back', language)}</span>
                 </button>
             </header>
             <main className="form-main">
@@ -25,7 +34,7 @@ const WorkInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
                         <div className="form-group"><select className="form-input"><option value="">Average Monthly Income</option><option value="low">Less than 2000</option><option value="medium">2000 - 5000</option><option value="high">More than 5000</option></select></div>
                     </div>
                 </form>
-                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>Next</button></div>
+                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>
             </main>
         </div>
     );

--- a/src/components/common/LanguageSwitcher.js
+++ b/src/components/common/LanguageSwitcher.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { t } from '../../i18n';
+
+const LanguageSwitcher = () => {
+  const { language, toggleLanguage } = useLanguage();
+  return (
+    <div className="language-switcher" onClick={toggleLanguage}>
+      <span className={language === 'en' ? 'active' : ''}>{t('english', language)}</span>
+      <span className={language === 'ar' ? 'active' : ''}>{t('arabic', language)}</span>
+    </div>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/contexts/LanguageContext.js
+++ b/src/contexts/LanguageContext.js
@@ -1,0 +1,18 @@
+import React, { useState, createContext, useContext } from 'react';
+
+export const LanguageContext = createContext();
+export const useLanguage = () => useContext(LanguageContext);
+
+export const LanguageProvider = ({ children }) => {
+  const [language, setLanguage] = useState('en');
+
+  const toggleLanguage = () => {
+    setLanguage(prev => (prev === 'en' ? 'ar' : 'en'));
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, toggleLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -11,7 +11,15 @@ const translations = {
   completeAccount: { en: 'Complete Account Opening', ar: 'إتمام عملية فتح الحساب' },
   welcomeSub: { en: 'Your gateway to modern banking services', ar: 'بوابتكم للخدمات المصرفية الحديثة' },
   welcomeTitle: { en: 'Daman Islamic Bank', ar: 'مصرف الضمان الإسلامي' },
-  submitRequest: { en: 'Submit Application', ar: 'إرسال الطلب' }
+  submitRequest: { en: 'Submit Application', ar: 'إرسال الطلب' },
+  successTitle: { en: 'Success!', ar: 'تم بنجاح!' },
+  successMsg: {
+    en: 'Your request has been submitted successfully. We will contact you shortly.',
+    ar: 'تم تقديم طلبك بنجاح. سوف نتواصل معك قريباً.'
+  },
+  backToHome: { en: 'Back to Home', ar: 'العودة للرئيسية' },
+  english: { en: 'English', ar: 'الإنجليزية' },
+  arabic: { en: 'Arabic', ar: 'العربية' }
 };
 
 export const t = (key, lang = 'en') => {

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -142,6 +142,30 @@ const GlobalStyles = () => (
         color: #fff;
     }
 
+    /* --- Language Switcher --- */
+    .language-switcher {
+        display: flex;
+        align-items: center;
+        background-color: rgba(0,0,0,0.1);
+        border-radius: 99px;
+        cursor: pointer;
+        font-size: 0.9rem;
+    }
+    .language-switcher span {
+        padding: 6px 12px;
+        color: var(--text-color-dark);
+        user-select: none;
+        transition: background-color 0.3s ease, color 0.3s ease;
+    }
+    body[data-theme='dark'] .language-switcher span {
+        color: var(--text-color-dark-dark);
+    }
+    .language-switcher span.active {
+        background-color: var(--primary-color);
+        color: var(--text-color-light);
+        border-radius: 99px;
+    }
+
 
     /* --- Language Selection --- */
     .lang-selection-page {


### PR DESCRIPTION
## Summary
- implement `LanguageContext` for global locale state
- create `LanguageSwitcher` component and styles
- add Arabic translations and new phrases
- integrate language switching across major pages

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686850305114832f8074bd5f382d105b