### PR TITLE
Update UI translations and personal info form

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -78,7 +78,7 @@ const AppContent = () => {
                 return <ContactInfoPage_EN onNavigate={handleNavigation} backPage={backPage} nextPage="workInfo" />;
             }
             case 'workInfo': return <WorkInfoPage_EN onNavigate={handleNavigation} backPage="contactInfo" nextPage="personalInfo" />;
-            case 'personalInfo': return <PersonalInfoPage_EN onNavigate={handleNavigation} backPage="workInfo" />;
+            case 'personalInfo': return <PersonalInfoPage_EN onNavigate={handleNavigation} backPage="workInfo" flow={flow} />;
             
             case 'success': return <SuccessPage_EN onNavigate={handleNavigation} />;
             default: return <LanguageSelectionPage onNavigate={handleNavigation} />;

--- a/src/accountOpening/CompaniesDocsPage_EN.js
+++ b/src/accountOpening/CompaniesDocsPage_EN.js
@@ -12,7 +12,7 @@ const CompaniesDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                <div style={{ display: 'flex', gap: '20px' }}>
+                <div style={{ display: 'flex', gap: '30px' }}>
                     <ThemeSwitcher />
                     <LanguageSwitcher />
                 </div>

--- a/src/accountOpening/CompanyContactPage_EN.js
+++ b/src/accountOpening/CompanyContactPage_EN.js
@@ -12,7 +12,7 @@ const CompanyContactPage_EN = ({ onNavigate, backPage, nextPage }) => {
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                <div style={{ display: 'flex', gap: '20px' }}>
+                <div style={{ display: 'flex', gap: '30px' }}>
                     <ThemeSwitcher />
                     <LanguageSwitcher />
                 </div>

--- a/src/accountOpening/CompanyInfoPage_EN.js
+++ b/src/accountOpening/CompanyInfoPage_EN.js
@@ -14,7 +14,7 @@ const CompanyInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                <div style={{ display: 'flex', gap: '20px' }}>
+                <div style={{ display: 'flex', gap: '30px' }}>
                     <ThemeSwitcher />
                     <LanguageSwitcher />
                 </div>

--- a/src/accountOpening/ContactInfoPage_EN.js
+++ b/src/accountOpening/ContactInfoPage_EN.js
@@ -13,7 +13,7 @@ const ContactInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                <div style={{ display: 'flex', gap: '20px' }}>
+                <div style={{ display: 'flex', gap: '30px' }}>
                     <ThemeSwitcher />
                     <LanguageSwitcher />
                 </div>

--- a/src/accountOpening/ExpatDocsPage_EN.js
+++ b/src/accountOpening/ExpatDocsPage_EN.js
@@ -12,7 +12,7 @@ const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                <div style={{ display: 'flex', gap: '20px' }}>
+                <div style={{ display: 'flex', gap: '30px' }}>
                     <ThemeSwitcher />
                     <LanguageSwitcher />
                 </div>
@@ -27,8 +27,6 @@ const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
                     <div className="upload-box"><p>Passport Photo</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
                     <div className="upload-box"><p>Account Opening Letter from Employer</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
                     <div className="upload-box"><p>Recent Personal Photo</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>رقم بطاقة الحصر</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>تاريخ انتهاء الاقامة</p><div className="upload-placeholder"><input type="date" className="form-input" /></div></div>
                     <div className="upload-box"><p>صورة من بطاقة الحصر</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
                 </div>
                 <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>

--- a/src/accountOpening/FinancialInfoPage_EN.js
+++ b/src/accountOpening/FinancialInfoPage_EN.js
@@ -13,7 +13,7 @@ const FinancialInfoPage_EN = ({ onNavigate, backPage }) => {
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                <div style={{ display: 'flex', gap: '20px' }}>
+                <div style={{ display: 'flex', gap: '30px' }}>
                     <ThemeSwitcher />
                     <LanguageSwitcher />
                 </div>

--- a/src/accountOpening/LandingPage_EN.js
+++ b/src/accountOpening/LandingPage_EN.js
@@ -11,7 +11,7 @@ const LandingPage_EN = ({ onNavigate }) => {
   const { language } = useLanguage();
   return (
     <div className="landing-container">
-      <div style={{ position: 'absolute', top: 20, right: 20, display: 'flex', gap: '20px' }}>
+      <div style={{ position: 'absolute', top: 20, right: 20, display: 'flex', gap: '30px' }}>
         <ThemeSwitcher />
                     <LanguageSwitcher />
       </div>

--- a/src/accountOpening/LegalRepInfoPage_EN.js
+++ b/src/accountOpening/LegalRepInfoPage_EN.js
@@ -14,7 +14,7 @@ const LegalRepInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                <div style={{ display: 'flex', gap: '20px' }}>
+                <div style={{ display: 'flex', gap: '30px' }}>
                     <ThemeSwitcher />
                     <LanguageSwitcher />
                 </div>

--- a/src/accountOpening/PersonalInfoPage_EN.js
+++ b/src/accountOpening/PersonalInfoPage_EN.js
@@ -8,49 +8,49 @@ import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
 
-const PersonalInfoPage_EN = ({ onNavigate, backPage }) => {
+const PersonalInfoPage_EN = ({ onNavigate, backPage, flow }) => {
     const { language } = useLanguage();
     const [form, setForm] = useState({
         fullName: '',
-        nameEn: '',
+        firstNameEn: '',
+        middleNameEn: '',
+        lastNameEn: '',
         dob: '',
         gender: '',
         nationality: '',
-        nid: '',
+        nidDigits: Array(12).fill(''),
         phone: '',
-        email: ''
+        enableEmail: false,
+        email: '',
+        residenceExpiry: '',
+        censusCardNumber: ''
     });
 
     const [agreements, setAgreements] = useState({ agree1: false, agree2: false });
 
-    const handleChange = (e) => {
+    const handleChange = (e, index) => {
         const { name, value, type, checked } = e.target;
         if (name.startsWith('agree')) {
             setAgreements(a => ({ ...a, [name]: checked }));
+        } else if (name === 'enableEmail') {
+            setForm(f => ({ ...f, enableEmail: checked }));
+        } else if (name.startsWith('nidDigit')) {
+            const digits = [...form.nidDigits];
+            digits[index] = value.replace(/[^0-9]/g, '').slice(-1);
+            setForm(f => ({ ...f, nidDigits: digits }));
         } else {
             setForm(f => ({ ...f, [name]: value }));
-            if (name === 'nid') {
-                if (value.length >= 1) {
-                    const g = value[0] === '1' ? 'male' : value[0] === '2' ? 'female' : '';
-                    if (g) setForm(f => ({ ...f, gender: g }));
-                }
-                if (value.length >= 5) {
-                    const year = parseInt(value.slice(1,5));
-                    const age = new Date().getFullYear() - year;
-                    if (!isNaN(year) && age >= 18 && age <= 120) {
-                        setForm(f => ({ ...f, dob: `${year}-01-01` }));
-                    }
-                }
-            }
         }
     };
 
     const validateNID = () => {
-        if (form.nid.length < 5) return false;
-        const genderDigit = form.nid[0];
+        const nid = form.nidDigits.join('');
+        if (flow === 'expat') return true;
+        if (nid.length !== 12) return false;
+        const genderDigit = nid[0];
         if (genderDigit === "1" && form.gender !== "male") return false;
         if (genderDigit === "2" && form.gender !== "female") return false;
-        const year = parseInt(form.nid.slice(1,5));
+        const year = parseInt(nid.slice(1,5));
         if (isNaN(year)) return false;
         const age = new Date().getFullYear() - year;
         if (age < 18 || age > 120) return false;
@@ -76,7 +76,7 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage }) => {
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                <div style={{ display: 'flex', gap: '20px' }}>
+                <div style={{ display: 'flex', gap: '30px' }}>
                     <ThemeSwitcher />
                     <LanguageSwitcher />
                 </div>
@@ -88,15 +88,30 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage }) => {
             <main className="form-main">
                 <form className="form-container" onSubmit={e => {e.preventDefault(); handleSubmit();}}>
                     <div className="form-section">
-                        <h3>Personal Information</h3>
-                        <div className="form-group"><input name="fullName" value={form.fullName} onChange={handleChange} required type="text" className="form-input" placeholder="Full Name" /></div>
-                        <div className="form-group"><input name="nameEn" value={form.nameEn} onChange={handleChange} required type="text" className="form-input" placeholder="Full Name (English)" /></div>
-                        <div className="form-group date-input-container"><input name="dob" value={form.dob} required type="text" className="form-input" placeholder="Date of Birth" onFocus={(e) => e.target.type='date'} onBlur={(e) => e.target.type='text'} onChange={handleChange}/><CalendarIcon/></div>
-                        <div className="form-group"><select name="gender" value={form.gender} onChange={handleChange} required className="form-input"><option value="">Gender</option><option value="male">Male</option><option value="female">Female</option></select></div>
-                        <div className="form-group"><select name="nationality" value={form.nationality} onChange={handleChange} className="form-input"><option value="">Nationality</option><option value="libyan">Libyan</option><option value="other">Other</option></select></div>
-                        <div className="form-group"><input name="nid" value={form.nid} onChange={handleChange} required type="text" maxLength="12" className="form-input" placeholder="National ID" /></div>
-                        <div className="form-group"><input name="phone" value={form.phone} onChange={handleChange} required type="tel" className="form-input" placeholder="Phone Number" /></div>
-                        <div className="form-group"><input name="email" value={form.email} onChange={handleChange} type="email" className="form-input" placeholder="Email (optional)" /></div>
+                        <h3>{t('personalInfo', language)}</h3>
+                        <div className="form-group"><input name="fullName" value={form.fullName} onChange={handleChange} required type="text" className="form-input" placeholder={t('fullName', language)} /></div>
+                        <div className="form-group"><input name="firstNameEn" value={form.firstNameEn} onChange={handleChange} required type="text" className="form-input" placeholder={t('firstNameEn', language)} /></div>
+                        <div className="form-group"><input name="middleNameEn" value={form.middleNameEn} onChange={handleChange} required type="text" className="form-input" placeholder={t('middleNameEn', language)} /></div>
+                        <div className="form-group"><input name="lastNameEn" value={form.lastNameEn} onChange={handleChange} required type="text" className="form-input" placeholder={t('lastNameEn', language)} /></div>
+                        <div className="form-group date-input-container"><input name="dob" value={form.dob} required type="text" className="form-input" placeholder={t('dateOfBirth', language)} onFocus={(e) => e.target.type='date'} onBlur={(e) => e.target.type='text'} onChange={handleChange}/><CalendarIcon/></div>
+                        <div className="form-group"><select name="gender" value={form.gender} onChange={handleChange} required className="form-input"><option value="">{t('gender', language)}</option><option value="male">{t('male', language)}</option><option value="female">{t('female', language)}</option></select></div>
+                        <div className="form-group"><select name="nationality" value={form.nationality} onChange={handleChange} className="form-input"><option value="">{t('nationality', language)}</option><option value="libyan">{t('libyan', language)}</option><option value="other">{t('other', language)}</option></select></div>
+                        {flow !== 'expat' && (
+                            <div className="form-group" style={{display:'flex', gap:'5px'}}>
+                                {form.nidDigits.map((d, idx) => (
+                                    <input key={idx} name={`nidDigit${idx}`} value={d} onChange={(e)=>handleChange(e, idx)} required type="text" maxLength="1" className="form-input" style={{width:'30px', textAlign:'center'}} />
+                                ))}
+                            </div>
+                        )}
+                        {flow === 'expat' && (
+                            <>
+                                <div className="form-group date-input-container"><input name="residenceExpiry" value={form.residenceExpiry} onChange={handleChange} required type="text" className="form-input" placeholder={t('residenceExpiry', language)} onFocus={e=>e.target.type='date'} onBlur={e=>e.target.type='text'} /><CalendarIcon/></div>
+                                <div className="form-group"><input name="censusCardNumber" value={form.censusCardNumber} onChange={handleChange} required type="text" className="form-input" placeholder={t('censusCardNumber', language)} /></div>
+                            </>
+                        )}
+                        <div className="form-group"><input name="phone" value={form.phone} onChange={handleChange} required type="tel" className="form-input" placeholder={t('phoneNumber', language)} /></div>
+                        <div className="form-group"><label><input type="checkbox" name="enableEmail" checked={form.enableEmail} onChange={handleChange} /> {t('enableEmail', language)}</label></div>
+                        {form.enableEmail && <div className="form-group"><input name="email" value={form.email} onChange={handleChange} required type="email" className="form-input" placeholder={t('email', language)} /></div>}
                     </div>
                     <div className="form-actions">
                         <div className="agreements">

--- a/src/accountOpening/SelectUserPage_EN.js
+++ b/src/accountOpening/SelectUserPage_EN.js
@@ -37,7 +37,7 @@ const SelectUserPage_EN = ({ onNavigate }) => {
     <div className="app-container">
       <header className="header">
         <img src={LOGO_COLOR} alt="Bank Logo" className="logo" />
-        <div style={{ display: 'flex', gap: '20px' }}>
+        <div style={{ display: 'flex', gap: '30px' }}>
           <ThemeSwitcher />
           <LanguageSwitcher />
         </div>

--- a/src/accountOpening/SimpleDocsPage_EN.js
+++ b/src/accountOpening/SimpleDocsPage_EN.js
@@ -13,7 +13,7 @@ const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                <div style={{ display: 'flex', gap: '20px' }}>
+                <div style={{ display: 'flex', gap: '30px' }}>
                     <ThemeSwitcher />
                     <LanguageSwitcher />
                 </div>

--- a/src/accountOpening/SuccessPage_EN.js
+++ b/src/accountOpening/SuccessPage_EN.js
@@ -10,7 +10,7 @@ const SuccessPage_EN = ({ onNavigate }) => {
     const { language } = useLanguage();
     return (
         <div className="success-page">
-            <div style={{ position: 'absolute', top: 20, right: 20, display: 'flex', gap: '20px' }}>
+            <div style={{ position: 'absolute', top: 20, right: 20, display: 'flex', gap: '30px' }}>
                 <ThemeSwitcher />
                 <LanguageSwitcher />
             </div>

--- a/src/accountOpening/WorkInfoPage_EN.js
+++ b/src/accountOpening/WorkInfoPage_EN.js
@@ -13,7 +13,7 @@ const WorkInfoPage_EN = ({ onNavigate, backPage, nextPage }) => {
         <div className="form-page">
             <header className="header docs-header">
                 <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
-                <div style={{ display: 'flex', gap: '20px' }}>
+                <div style={{ display: 'flex', gap: '30px' }}>
                     <ThemeSwitcher />
                     <LanguageSwitcher />
                 </div>

--- a/src/common/Footer.js
+++ b/src/common/Footer.js
@@ -1,9 +1,12 @@
 import React from 'react';
+import { useLanguage } from '../contexts/LanguageContext';
+import { t } from '../i18n';
 
 const Footer = () => {
+  const { language } = useLanguage();
   return (
     <footer className="footer">
-      © {new Date().getFullYear()} Daman Islamic Bank
+      {t('copyRight', language)}
     </footer>
   );
 };

--- a/src/eServices/EServicesLandingPage.js
+++ b/src/eServices/EServicesLandingPage.js
@@ -10,7 +10,7 @@ const EServicesLanding = ({ onNavigate }) => {
   const { language } = useLanguage();
   return (
     <div className="landing-container">
-      <div style={{ position: 'absolute', top: 20, right: 20, display: 'flex', gap: '20px' }}>
+      <div style={{ position: 'absolute', top: 20, right: 20, display: 'flex', gap: '30px' }}>
         <ThemeSwitcher />
         <LanguageSwitcher />
       </div>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -22,7 +22,26 @@ const translations = {
   eservicesTitle: { en: 'E-Services Registration', ar: 'التسجيل في الخدمات الإلكترونية' },
   eservicesSub: { en: 'This service is under construction.', ar: 'هذه الخدمة قيد التطوير' },
   english: { en: 'English', ar: 'الإنجليزية' },
-  arabic: { en: 'Arabic', ar: 'العربية' }
+  arabic: { en: 'Arabic', ar: 'العربية' },
+  copyRight: { en: `© ${new Date().getFullYear()} Daman Islamic Bank`, ar: `© ${new Date().getFullYear()} مصرف الضمان الإسلامي` },
+  personalInfo: { en: 'Personal Information', ar: 'المعلومات الشخصية' },
+  fullName: { en: 'Full Name', ar: 'الاسم الكامل' },
+  firstNameEn: { en: 'First Name (English)', ar: 'الاسم الأول بالإنجليزية' },
+  middleNameEn: { en: 'Middle Name (English)', ar: 'اسم الأب بالإنجليزية' },
+  lastNameEn: { en: 'Last Name (English)', ar: 'اسم العائلة بالإنجليزية' },
+  dateOfBirth: { en: 'Date of Birth', ar: 'تاريخ الميلاد' },
+  gender: { en: 'Gender', ar: 'الجنس' },
+  male: { en: 'Male', ar: 'ذكر' },
+  female: { en: 'Female', ar: 'أنثى' },
+  nationality: { en: 'Nationality', ar: 'الجنسية' },
+  libyan: { en: 'Libyan', ar: 'ليبي' },
+  other: { en: 'Other', ar: 'أخرى' },
+  nid: { en: 'National ID', ar: 'الرقم الوطني' },
+  phoneNumber: { en: 'Phone Number', ar: 'رقم الهاتف' },
+  enableEmail: { en: 'Enable Email', ar: 'تفعيل البريد الإلكتروني' },
+  email: { en: 'Email', ar: 'البريد الإلكتروني' },
+  residenceExpiry: { en: 'Residence Expiry Date', ar: 'تاريخ انتهاء الاقامة' },
+  censusCardNumber: { en: 'Census Card Number', ar: 'رقم بطاقة الحصر' }
 };
 
 export const t = (key, lang = 'en') => {

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -205,6 +205,7 @@ const GlobalStyles = () => (
     /* --- Landing Page --- */
     .landing-container {
         display: flex;
+        flex-direction: column;
         justify-content: center;
         align-items: center;
         min-height: 100vh;
@@ -215,7 +216,7 @@ const GlobalStyles = () => (
         animation: gradient-animation 15s ease infinite;
         color: var(--text-color-light);
     }
-    .content-wrapper { display: flex; flex-direction: column; align-items: center; max-width: 500px; animation: fadeInSlideUp 1s ease-out forwards; }
+    .content-wrapper { display: flex; flex-direction: column; align-items: center; justify-content: center; flex: 1; max-width: 500px; animation: fadeInSlideUp 1s ease-out forwards; }
     .landing-logo { height: 140px; margin-bottom: 20px; filter: drop-shadow(0px 8px 20px rgba(0, 0, 0, 0.3)); }
     .landing-title { font-size: 3rem; font-weight: 700; margin: 0 0 10px 0; letter-spacing: 1px; }
     .landing-subtitle { font-size: 1.25rem; font-weight: 400; opacity: 0.9; margin-bottom: 40px; }
@@ -286,11 +287,11 @@ const GlobalStyles = () => (
     .form-main { padding: 40px; display: flex; flex-direction: column; align-items: center; flex-grow: 1; }
     .form-title { font-size: 2.5rem; font-weight: 700; color: var(--text-color-dark); margin-bottom: 40px; align-self: flex-start; }
     .docs-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 30px; width: 100%; max-width: 900px; margin-bottom: 50px; }
-    .upload-box { background-color: var(--form-input-bg); border-radius: 15px; padding: 20px; display: flex; align-items: center; justify-content: space-between; box-shadow: 0 5px 15px var(--shadow-color); transition: all 0.3s ease; gap: 15px; }
+    .upload-box { background-color: var(--form-input-bg); border-radius: 15px; padding: 20px; display: flex; align-items: center; justify-content: space-between; box-shadow: 0 5px 15px var(--shadow-color); transition: all 0.3s ease; gap: 15px; border: 2px dashed var(--primary-color); }
     .upload-box p { color: var(--text-color-dark); }
-    .upload-box:hover { transform: translateY(-5px); box-shadow: 0 8px 25px rgba(0,0,0,0.12); }
+    .upload-box:hover { transform: translateY(-5px); box-shadow: 0 8px 25px rgba(0,0,0,0.12); background-color: var(--secondary-color); }
     .upload-box p { font-size: 1.1rem; font-weight: 600; margin: 0; flex-grow: 1; }
-    .upload-placeholder { width: 100px; height: 100px; border: 2px dashed #ccc; border-radius: 10px; display: flex; align-items: center; justify-content: center; color: #aaa; cursor: pointer; flex-shrink: 0; }
+    .upload-placeholder { width: 100px; height: 100px; border: 2px dashed var(--primary-color); border-radius: 10px; display: flex; align-items: center; justify-content: center; color: var(--primary-color); cursor: pointer; flex-shrink: 0; }
     .multi-upload-placeholders { display: flex; gap: 10px; }
     .multi-upload-placeholders .upload-placeholder { width: 60px; height: 60px; }
     .multi-upload-placeholders .upload-icon { width: 32px; height: 32px; }
@@ -342,6 +343,7 @@ const GlobalStyles = () => (
         padding: 20px;
         color: var(--text-color-dark);
         background-color: var(--docs-bg);
+        margin-top: auto;
     }
     
     /* ---=== Success Page ===--- */


### PR DESCRIPTION
## Summary
- expanded i18n strings
- translated footer and placeholders
- improved landing layout and footer
- added email opt‑in and expat fields
- split national ID digits and tweaked document upload style

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686869314fa0832fad2c7528223df2e4