### PR TITLE
Add confirmation page and improve theme features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/App.js
+++ b/src/App.js
@@ -19,12 +19,13 @@ import CompanyContactPage_EN from './accountOpening/CompanyContactPage_EN';
 import LegalRepInfoPage_EN from './accountOpening/LegalRepInfoPage_EN';
 import FinancialInfoPage_EN from './accountOpening/FinancialInfoPage_EN';
 import SuccessPage_EN from './accountOpening/SuccessPage_EN';
+import ConfirmPage_EN from './accountOpening/ConfirmPage_EN';
 import EServicesLanding from './eServices/EServicesLandingPage';
 
 
 // ---=== Main App Component ===---
 const AppContent = () => {
-  const [navigation, setNavigation] = useState({ page: 'languageSelection', flow: null });
+  const [navigation, setNavigation] = useState({ page: 'languageSelection', flow: null, state: null });
   const { theme } = useTheme();
   const { language } = useLanguage();
 
@@ -33,7 +34,7 @@ const AppContent = () => {
     document.body.setAttribute('data-theme', theme);
   }, [theme, language]);
 
-  const handleNavigation = (page) => {
+  const handleNavigation = (page, state = null) => {
     let currentFlow = navigation.flow;
 
     if (page.startsWith('personal')) currentFlow = 'personal';
@@ -43,11 +44,11 @@ const AppContent = () => {
     else if (page.startsWith('companies')) currentFlow = 'companies';
     else if (page === 'selectUser' || page === 'landing' || page === 'languageSelection' || page === 'success') currentFlow = null;
 
-    setNavigation({ page, flow: currentFlow });
+    setNavigation({ page, flow: currentFlow, state });
   };
 
   const renderPage = () => {
-      const { page, flow } = navigation;
+      const { page, flow, state } = navigation;
 
       if (page === 'languageSelection') {
           return <LanguageSelectionPage onNavigate={handleNavigation} />;
@@ -78,7 +79,8 @@ const AppContent = () => {
                 return <ContactInfoPage_EN onNavigate={handleNavigation} backPage={backPage} nextPage="workInfo" />;
             }
             case 'workInfo': return <WorkInfoPage_EN onNavigate={handleNavigation} backPage="contactInfo" nextPage="personalInfo" />;
-            case 'personalInfo': return <PersonalInfoPage_EN onNavigate={handleNavigation} backPage="workInfo" flow={flow} />;
+            case 'personalInfo': return <PersonalInfoPage_EN onNavigate={handleNavigation} backPage="workInfo" flow={flow} state={state} />;
+            case 'confirm': return <ConfirmPage_EN onNavigate={handleNavigation} state={state} />;
             
             case 'success': return <SuccessPage_EN onNavigate={handleNavigation} />;
             default: return <LanguageSelectionPage onNavigate={handleNavigation} />;

--- a/src/accountOpening/ConfirmPage_EN.js
+++ b/src/accountOpening/ConfirmPage_EN.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { LOGO_WHITE } from '../assets/imagePaths';
+import ThemeSwitcher from '../common/ThemeSwitcher';
+import LanguageSwitcher from '../common/LanguageSwitcher';
+import Footer from '../common/Footer';
+import { t } from '../i18n';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const ConfirmPage_EN = ({ onNavigate, state }) => {
+    const { language } = useLanguage();
+    const form = state?.form || {};
+
+    const handleConfirm = () => {
+        const phoneOtp = Math.floor(1000 + Math.random() * 9000).toString();
+        const enteredPhone = prompt(`Enter OTP sent to phone (${phoneOtp})`);
+        if (enteredPhone !== phoneOtp) { alert('Incorrect OTP'); return; }
+        if (form.email) {
+            const emailOtp = Math.floor(1000 + Math.random() * 9000).toString();
+            const enteredEmail = prompt(`Enter OTP sent to email (${emailOtp})`);
+            if (enteredEmail !== emailOtp) { alert('Incorrect email OTP'); return; }
+        }
+        onNavigate('success');
+    };
+
+    return (
+        <div className="form-page">
+            <header className="header docs-header">
+                <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
+                <div style={{ display: 'flex', gap: '30px' }}>
+                    <ThemeSwitcher />
+                    <LanguageSwitcher />
+                </div>
+            </header>
+            <main className="form-main">
+                <div className="form-section">
+                    <h3>{t('confirmData', language)}</h3>
+                    <ul style={{ listStyle: 'none', padding: 0 }}>
+                        <li><strong>{t('fullName', language)}:</strong> {form.fullName}</li>
+                        <li><strong>{t('firstNameEn', language)}:</strong> {form.firstNameEn}</li>
+                        <li><strong>{t('middleNameEn', language)}:</strong> {form.middleNameEn}</li>
+                        <li><strong>{t('lastNameEn', language)}:</strong> {form.lastNameEn}</li>
+                        <li><strong>{t('dateOfBirth', language)}:</strong> {form.dob}</li>
+                        <li><strong>{t('gender', language)}:</strong> {form.gender}</li>
+                        <li><strong>{t('nationality', language)}:</strong> {form.nationality}</li>
+                        {form.nidDigits && (
+                            <li><strong>{t('nid', language)}:</strong> {form.nidDigits.join('')}</li>
+                        )}
+                        {form.residenceExpiry && (
+                            <li><strong>{t('residenceExpiry', language)}:</strong> {form.residenceExpiry}</li>
+                        )}
+                        {form.censusCardNumber && (
+                            <li><strong>{t('censusCardNumber', language)}:</strong> {form.censusCardNumber}</li>
+                        )}
+                        <li><strong>{t('phoneNumber', language)}:</strong> {form.phone}</li>
+                        {form.enableEmail && (
+                            <li><strong>{t('email', language)}:</strong> {form.email}</li>
+                        )}
+                    </ul>
+                </div>
+                <div className="form-actions">
+                    <button className="btn-next" onClick={handleConfirm}>{t('confirm', language)}</button>
+                </div>
+            </main>
+            <Footer />
+        </div>
+    );
+};
+
+export default ConfirmPage_EN;

--- a/src/accountOpening/LandingPage_EN.js
+++ b/src/accountOpening/LandingPage_EN.js
@@ -1,14 +1,16 @@
 import React from 'react';
-import { LOGO_WHITE } from '../assets/imagePaths';
+import { LOGO_WHITE, LOGO_COLOR } from '../assets/imagePaths';
 import { OpenAccountIcon, CompleteAccountIcon } from '../common/Icons';
 import LanguageSwitcher from '../common/LanguageSwitcher';
 import ThemeSwitcher from '../common/ThemeSwitcher';
 import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
+import { useTheme } from '../contexts/ThemeContext';
 
 const LandingPage_EN = ({ onNavigate }) => {
   const { language } = useLanguage();
+  const { theme } = useTheme();
   return (
     <div className="landing-container">
       <div style={{ position: 'absolute', top: 20, right: 20, display: 'flex', gap: '30px' }}>
@@ -16,7 +18,7 @@ const LandingPage_EN = ({ onNavigate }) => {
                     <LanguageSwitcher />
       </div>
       <div className="content-wrapper">
-        <img src={LOGO_WHITE} alt="Bank Logo" className="landing-logo" />
+        <img src={theme === 'light' ? LOGO_COLOR : LOGO_WHITE} alt="Bank Logo" className="landing-logo" />
         <h1 className="landing-title">{t('welcomeTitle', language)}</h1>
         <p className="landing-subtitle">{t('welcomeSub', language)}</p>
         <div className="landing-buttons-container">
@@ -34,7 +36,7 @@ const LandingPage_EN = ({ onNavigate }) => {
           </button>
         </div>
       </div>
-      <Footer />
+      <Footer noBackground />
     </div>
   );
 };

--- a/src/accountOpening/PersonalInfoPage_EN.js
+++ b/src/accountOpening/PersonalInfoPage_EN.js
@@ -8,9 +8,9 @@ import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
 
-const PersonalInfoPage_EN = ({ onNavigate, backPage, flow }) => {
+const PersonalInfoPage_EN = ({ onNavigate, backPage, flow, state }) => {
     const { language } = useLanguage();
-    const [form, setForm] = useState({
+    const [form, setForm] = useState(state?.form || {
         fullName: '',
         firstNameEn: '',
         middleNameEn: '',
@@ -50,6 +50,20 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow }) => {
         }
     };
 
+    const handleNIDPaste = (e, index) => {
+        const paste = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, form.nidDigits.length - index);
+        if (!paste) return;
+        e.preventDefault();
+        const digits = [...form.nidDigits];
+        for (let i = 0; i < paste.length; i++) {
+            digits[index + i] = paste[i];
+        }
+        setForm(f => ({ ...f, nidDigits: digits }));
+        const inputs = e.target.parentElement.querySelectorAll('input');
+        const next = index + paste.length;
+        if (inputs[next]) inputs[next].focus();
+    };
+
     const validateNID = () => {
         const nid = form.nidDigits.join('');
         if (flow === 'expat') return true;
@@ -68,15 +82,7 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow }) => {
     const handleSubmit = () => {
         if (!validateNID()) { alert('Invalid National ID'); return; }
         if (!agreements.agree1 || !agreements.agree2) { alert('You must agree to proceed'); return; }
-        const phoneOtp = Math.floor(1000 + Math.random()*9000).toString();
-        const enteredPhone = prompt(`Enter OTP sent to phone (${phoneOtp})`);
-        if (enteredPhone !== phoneOtp) { alert('Incorrect OTP'); return; }
-        if (form.email) {
-            const emailOtp = Math.floor(1000 + Math.random()*9000).toString();
-            const enteredEmail = prompt(`Enter OTP sent to email (${emailOtp})`);
-            if (enteredEmail !== emailOtp) { alert('Incorrect email OTP'); return; }
-        }
-        onNavigate('success');
+        onNavigate('confirm', { form });
     };
 
     return (
@@ -106,7 +112,18 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow }) => {
                         {flow !== 'expat' && (
                             <div className="form-group" style={{display:'flex', gap:'5px'}}>
                                 {form.nidDigits.map((d, idx) => (
-                                    <input key={idx} name={`nidDigit${idx}`} value={d} onChange={(e)=>handleChange(e, idx)} onKeyDown={(e)=>handleNIDKeyDown(e, idx)} required type="text" maxLength="1" className="form-input" style={{width:'30px', textAlign:'center'}} />
+                                    <input
+                                        key={idx}
+                                        name={`nidDigit${idx}`}
+                                        value={d}
+                                        onChange={(e)=>handleChange(e, idx)}
+                                        onKeyDown={(e)=>handleNIDKeyDown(e, idx)}
+                                        onPaste={(e)=>handleNIDPaste(e, idx)}
+                                        required
+                                        type="text"
+                                        maxLength="1"
+                                        className="national-id-input"
+                                    />
                                 ))}
                             </div>
                         )}

--- a/src/common/Footer.js
+++ b/src/common/Footer.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { t } from '../i18n';
 
-const Footer = () => {
+const Footer = ({ noBackground = false }) => {
   const { language } = useLanguage();
   return (
-    <footer className="footer">
+    <footer className={`footer${noBackground ? ' footer-transparent' : ''}`}>
       {t('copyRight', language)}
     </footer>
   );

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -57,7 +57,9 @@ const translations = {
   monthlyIncome: { en: 'Average Monthly Income', ar: 'متوسط الدخل الشهري' },
   certifyCorrect: { en: 'I certify that all data entered is correct.', ar: 'أقر بأن جميع البيانات المدخلة صحيحة.' },
   agreeTerms: { en: 'I agree to the Terms and Conditions.', ar: 'أوافق على الشروط والأحكام.' },
-  censusCardPhoto: { en: 'Census Card Photo', ar: 'صورة من بطاقة الحصر' }
+  censusCardPhoto: { en: 'Census Card Photo', ar: 'صورة من بطاقة الحصر' },
+  confirmData: { en: 'Please confirm your information', ar: 'يرجى تأكيد المعلومات المدخلة' },
+  confirm: { en: 'Confirm', ar: 'تأكيد' }
 };
 
 export const t = (key, lang = 'en') => {

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -339,6 +339,7 @@ const GlobalStyles = () => (
         background-color: var(--docs-bg);
         margin-top: auto;
     }
+    .footer-transparent { background-color: transparent; }
     
     /* ---=== Success Page ===--- */
     .success-page {


### PR DESCRIPTION
## Summary
- add confirm page before OTP submission
- switch logo color with theme on landing page
- allow pasting into national ID fields
- remove landing page footer background
- support navigation state and add translations

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686873774d24832fa2cfe8f1426c3f28