### PR TITLE
Implement passport OCR and PDF export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,12 @@
                 "@testing-library/jest-dom": "^5.17.0",
                 "@testing-library/react": "^13.4.0",
                 "@testing-library/user-event": "^13.5.0",
+                "jspdf": "^3.0.1",
+                "mrz": "^4.2.1",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
                 "react-scripts": "5.0.1",
+                "tesseract.js": "^6.0.1",
                 "web-vitals": "^2.1.4"
             }
         },
@@ -4513,6 +4516,13 @@
             "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
             "license": "MIT"
         },
+        "node_modules/@types/raf": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+            "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@types/range-parser": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -5577,6 +5587,18 @@
                 "node": ">= 4.0.0"
             }
         },
+        "node_modules/atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "license": "(MIT OR Apache-2.0)",
+            "bin": {
+                "atob": "bin/atob.js"
+            },
+            "engines": {
+                "node": ">= 4.5.0"
+            }
+        },
         "node_modules/autoprefixer": {
             "version": "10.4.21",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -5932,6 +5954,16 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "license": "MIT"
         },
+        "node_modules/base64-arraybuffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+            "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5979,6 +6011,12 @@
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "license": "MIT"
+        },
+        "node_modules/bmp-js": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+            "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
             "license": "MIT"
         },
         "node_modules/body-parser": {
@@ -6115,6 +6153,18 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "node-int64": "^0.4.0"
+            }
+        },
+        "node_modules/btoa": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+            "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+            "license": "(MIT OR Apache-2.0)",
+            "bin": {
+                "btoa": "bin/btoa.js"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
             }
         },
         "node_modules/buffer-from": {
@@ -6262,6 +6312,26 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/canvg": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+            "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime": "^7.12.5",
+                "@types/raf": "^3.4.0",
+                "core-js": "^3.8.3",
+                "raf": "^3.4.1",
+                "regenerator-runtime": "^0.13.7",
+                "rgbcolor": "^1.0.1",
+                "stackblur-canvas": "^2.0.0",
+                "svg-pathdata": "^6.0.3"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
         },
         "node_modules/case-sensitive-paths-webpack-plugin": {
             "version": "2.4.0",
@@ -6802,6 +6872,16 @@
             },
             "peerDependencies": {
                 "postcss": "^8.4"
+            }
+        },
+        "node_modules/css-line-break": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+            "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "utrie": "^1.0.2"
             }
         },
         "node_modules/css-loader": {
@@ -7557,6 +7637,16 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+            "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optional": true,
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/domutils": {
@@ -8820,6 +8910,12 @@
                 "bser": "2.1.1"
             }
         },
+        "node_modules/fflate": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+            "license": "MIT"
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9806,6 +9902,20 @@
                 }
             }
         },
+        "node_modules/html2canvas": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+            "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "css-line-break": "^2.1.0",
+                "text-segmentation": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/htmlparser2": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -9956,6 +10066,12 @@
             "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
             "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
             "license": "ISC"
+        },
+        "node_modules/idb-keyval": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+            "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+            "license": "Apache-2.0"
         },
         "node_modules/identity-obj-proxy": {
             "version": "3.0.0",
@@ -10562,6 +10678,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+            "license": "MIT"
+        },
+        "node_modules/is-url": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
             "license": "MIT"
         },
         "node_modules/is-weakmap": {
@@ -13264,6 +13386,24 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/jspdf": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+            "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.26.7",
+                "atob": "^2.1.2",
+                "btoa": "^1.2.1",
+                "fflate": "^0.8.1"
+            },
+            "optionalDependencies": {
+                "canvg": "^3.0.11",
+                "core-js": "^3.6.0",
+                "dompurify": "^3.2.4",
+                "html2canvas": "^1.0.0-rc.5"
+            }
+        },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.5",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -13745,6 +13885,12 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
+        "node_modules/mrz": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/mrz/-/mrz-4.2.1.tgz",
+            "integrity": "sha512-BM1PAHjw3DPQ0+Ub5yYlR4B+8CbEEC/8VC1xUazebBuJnfLDF2vNXysWSE02pU5o4JNDaLVvYyyHJ6Xut5H+EQ==",
+            "license": "MIT"
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13828,6 +13974,48 @@
             "dependencies": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/node-forge": {
@@ -14138,6 +14326,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/opencollective-postinstall": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+            "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+            "license": "MIT",
+            "bin": {
+                "opencollective-postinstall": "index.js"
             }
         },
         "node_modules/optionator": {
@@ -16658,6 +16855,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rgbcolor": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+            "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+            "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+            "optional": true,
+            "engines": {
+                "node": ">= 0.8.15"
+            }
+        },
         "node_modules/rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -17458,6 +17665,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/stackblur-canvas": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+            "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=0.1.14"
+            }
+        },
         "node_modules/stackframe": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -18002,6 +18219,16 @@
             "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
             "license": "MIT"
         },
+        "node_modules/svg-pathdata": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+            "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/svgo": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -18337,6 +18564,30 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "license": "MIT"
         },
+        "node_modules/tesseract.js": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-6.0.1.tgz",
+            "integrity": "sha512-/sPvMvrCtgxnNRCjbTYbr7BRu0yfWDsMZQ2a/T5aN/L1t8wUQN6tTWv6p6FwzpoEBA0jrN2UD2SX4QQFRdoDbA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bmp-js": "^0.1.0",
+                "idb-keyval": "^6.2.0",
+                "is-url": "^1.2.4",
+                "node-fetch": "^2.6.9",
+                "opencollective-postinstall": "^2.0.3",
+                "regenerator-runtime": "^0.13.3",
+                "tesseract.js-core": "^6.0.0",
+                "wasm-feature-detect": "^1.2.11",
+                "zlibjs": "^0.3.1"
+            }
+        },
+        "node_modules/tesseract.js-core": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-6.0.0.tgz",
+            "integrity": "sha512-1Qncm/9oKM7xgrQXZXNB+NRh19qiXGhxlrR8EwFbK5SaUbPZnS5OMtP/ghtqfd23hsr1ZvZbZjeuAGcMxd/ooA==",
+            "license": "Apache-2.0"
+        },
         "node_modules/test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -18349,6 +18600,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/text-segmentation": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+            "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "utrie": "^1.0.2"
             }
         },
         "node_modules/text-table": {
@@ -18869,6 +19130,16 @@
                 "node": ">= 0.4.0"
             }
         },
+        "node_modules/utrie": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+            "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "base64-arraybuffer": "^1.0.2"
+            }
+        },
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -18937,6 +19208,12 @@
             "dependencies": {
                 "makeerror": "1.0.12"
             }
+        },
+        "node_modules/wasm-feature-detect": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+            "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/watchpack": {
             "version": "2.4.4",
@@ -19843,6 +20120,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zlibjs": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+            "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -3,37 +3,39 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-      "@testing-library/jest-dom": "^5.17.0",
-      "@testing-library/react": "^13.4.0",
-      "@testing-library/user-event": "^13.5.0",
-      "react": "^18.3.1",
-      "react-dom": "^18.3.1",
-      "react-scripts": "5.0.1",
-      "web-vitals": "^2.1.4"
+        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/react": "^13.4.0",
+        "@testing-library/user-event": "^13.5.0",
+        "jspdf": "^3.0.1",
+        "mrz": "^4.2.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-scripts": "5.0.1",
+        "tesseract.js": "^6.0.1",
+        "web-vitals": "^2.1.4"
     },
     "scripts": {
-      "start": "react-scripts start",
-      "build": "react-scripts build",
-      "test": "react-scripts test",
-      "eject": "react-scripts eject"
+        "start": "react-scripts start",
+        "build": "react-scripts build",
+        "test": "react-scripts test",
+        "eject": "react-scripts eject"
     },
     "eslintConfig": {
-      "extends": [
-        "react-app",
-        "react-app/jest"
-      ]
+        "extends": [
+            "react-app",
+            "react-app/jest"
+        ]
     },
     "browserslist": {
-      "production": [
-        ">0.2%",
-        "not dead",
-        "not op_mini all"
-      ],
-      "development": [
-        "last 1 chrome version",
-        "last 1 firefox version",
-        "last 1 safari version"
-      ]
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
     }
-  }
-  
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ThemeProvider, useTheme } from './contexts/ThemeContext';
 import { LanguageProvider, useLanguage } from './contexts/LanguageContext';
+import { FormProvider } from './contexts/FormContext';
 import GlobalStyles from './styles/GlobalStyles';
 
 // Import Page Components
@@ -95,8 +96,10 @@ export default function App() {
     return (
         <LanguageProvider>
             <ThemeProvider>
-                <GlobalStyles />
-                <AppContent />
+                <FormProvider>
+                    <GlobalStyles />
+                    <AppContent />
+                </FormProvider>
             </ThemeProvider>
         </LanguageProvider>
     );

--- a/src/accountOpening/CompaniesDocsPage_EN.js
+++ b/src/accountOpening/CompaniesDocsPage_EN.js
@@ -24,13 +24,13 @@ const CompaniesDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
             <main className="form-main">
                 <h2 className="form-title">{t('requiredDocs', language)}</h2>
                 <div className="docs-grid">
-                    <div className="upload-box"><p>Bank statement for the last months (if any)</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>Tax Card or Certificate</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>Commercial Chamber Registration Certificate</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>Official authorization for the legal representative</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>Copy of the Commercial Register</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>Photos of National ID or Passport for authorized signatories</p><div className="multi-upload-placeholders"><input type="file" accept="image/*" capture="environment" multiple /></div></div>
-                    <div className="upload-box"><p>Recent personal photos for authorized signatories</p><div className="multi-upload-placeholders"><input type="file" accept="image/*" capture="environment" multiple /></div></div>
+                    <div className="upload-box"><p>{t('bankStatement', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('taxCard', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('commercialChamberCertificate', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('legalRepAuth', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('commercialRegisterCopy', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('nationalIdPhotos', language)}</p><div className="multi-upload-placeholders"><input type="file" accept="image/*" required capture="environment" multiple /></div></div>
+                    <div className="upload-box"><p>{t('personalPhotos', language)}</p><div className="multi-upload-placeholders"><input type="file" accept="image/*" required capture="environment" multiple /></div></div>
                 </div>
                 <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>
             </main>

--- a/src/accountOpening/ConfirmPage_EN.js
+++ b/src/accountOpening/ConfirmPage_EN.js
@@ -5,6 +5,7 @@ import LanguageSwitcher from '../common/LanguageSwitcher';
 import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
+import jsPDF from 'jspdf';
 
 const ConfirmPage_EN = ({ onNavigate, state }) => {
     const { language } = useLanguage();
@@ -20,6 +21,19 @@ const ConfirmPage_EN = ({ onNavigate, state }) => {
             if (enteredEmail !== emailOtp) { alert('Incorrect email OTP'); return; }
         }
         onNavigate('success');
+    };
+
+    const handleExport = () => {
+        const doc = new jsPDF();
+        doc.text('Account Confirmation', 10, 10);
+        let y = 20;
+        Object.entries(form).forEach(([k, v]) => {
+            if (!v) return;
+            const value = Array.isArray(v) ? v.join('') : v;
+            doc.text(`${k}: ${value}`, 10, y);
+            y += 10;
+        });
+        doc.save('confirmation.pdf');
     };
 
     return (
@@ -58,6 +72,7 @@ const ConfirmPage_EN = ({ onNavigate, state }) => {
                     </ul>
                 </div>
                 <div className="form-actions">
+                    <button className="btn-back" onClick={handleExport} style={{marginRight:'10px'}}>{language === 'ar' ? 'تصدير' : 'Export PDF'}</button>
                     <button className="btn-next" onClick={handleConfirm}>{t('confirm', language)}</button>
                 </div>
             </main>

--- a/src/accountOpening/ExpatDocsPage_EN.js
+++ b/src/accountOpening/ExpatDocsPage_EN.js
@@ -5,9 +5,43 @@ import LanguageSwitcher from '../common/LanguageSwitcher';
 import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
+import { useFormData } from '../contexts/FormContext';
+import Tesseract from 'tesseract.js';
+import { parse } from 'mrz';
 
 const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
     const { language } = useLanguage();
+    const { setFormData } = useFormData();
+
+    const handlePassportUpload = async (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        try {
+            const { data: { text } } = await Tesseract.recognize(file, 'eng');
+            const lines = text.split('\n').map(l => l.trim()).filter(Boolean).slice(-2).join('');
+            const result = parse(lines);
+            const fields = result.fields;
+            setFormData(data => ({
+                ...data,
+                personalInfo: {
+                    ...data.personalInfo,
+                    fullName: `${fields.lastName.replace(/</g,' ')} ${fields.firstName.replace(/</g,' ')}`.trim(),
+                    firstNameEn: fields.firstName.replace(/</g,' '),
+                    lastNameEn: fields.lastName.replace(/</g,' '),
+                    dob: formatDate(fields.dateOfBirth),
+                    passportExpiry: formatDate(fields.expirationDate)
+                }
+            }));
+        } catch(err) { console.error(err); }
+    };
+
+    const formatDate = (val) => {
+        if (!val) return '';
+        const year = val.slice(0,2);
+        const month = val.slice(2,4);
+        const day = val.slice(4,6);
+        return `20${year}-${month}-${day}`;
+    };
     return (
         <div className="form-page">
             <header className="header docs-header">
@@ -24,10 +58,10 @@ const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
             <main className="form-main">
                 <h2 className="form-title">{t('requiredDocs', language)}</h2>
                 <div className="docs-grid">
-                    <div className="upload-box"><p>Passport Photo</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>Account Opening Letter from Employer</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>Recent Personal Photo</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>{t('censusCardPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('passportPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required onChange={handlePassportUpload} capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('accountOpeningLetter', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('recentPersonalPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('censusCardPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
                 </div>
                 <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>
             </main>

--- a/src/accountOpening/PersonalInfoPage_EN.js
+++ b/src/accountOpening/PersonalInfoPage_EN.js
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
 import { CalendarIcon } from '../common/Icons';
 import ThemeSwitcher from '../common/ThemeSwitcher';
@@ -7,10 +7,36 @@ import LanguageSwitcher from '../common/LanguageSwitcher';
 import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
+import { useFormData } from '../contexts/FormContext';
 
 const PersonalInfoPage_EN = ({ onNavigate, backPage, flow, state }) => {
     const { language } = useLanguage();
-    const [form, setForm] = useState(state?.form || {
+    const { formData, setFormData } = useFormData();
+    const [form, setForm] = useState({
+        ...{
+            fullName: '',
+            firstNameEn: '',
+            middleNameEn: '',
+            lastNameEn: '',
+            dob: '',
+            gender: '',
+            nationality: '',
+            nidDigits: Array(12).fill(''),
+            phone: '',
+            enableEmail: false,
+            email: '',
+            residenceExpiry: '',
+            censusCardNumber: ''
+        },
+        ...(formData.personalInfo || {}),
+        ...(state?.form || {})
+    });
+
+    useEffect(() => {
+        if (formData.personalInfo) {
+            setForm(f => ({ ...f, ...formData.personalInfo }));
+        }
+    }, [formData.personalInfo]);
         fullName: '',
         firstNameEn: '',
         middleNameEn: '',
@@ -82,6 +108,7 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow, state }) => {
     const handleSubmit = () => {
         if (!validateNID()) { alert('Invalid National ID'); return; }
         if (!agreements.agree1 || !agreements.agree2) { alert('You must agree to proceed'); return; }
+        setFormData(data => ({ ...data, personalInfo: form }));
         onNavigate('confirm', { form });
     };
 

--- a/src/accountOpening/SimpleDocsPage_EN.js
+++ b/src/accountOpening/SimpleDocsPage_EN.js
@@ -6,9 +6,45 @@ import LanguageSwitcher from '../common/LanguageSwitcher';
 import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
+import { useFormData } from '../contexts/FormContext';
+import Tesseract from 'tesseract.js';
+import { parse } from 'mrz';
 
 const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
     const { language } = useLanguage();
+    const { setFormData } = useFormData();
+
+    const handlePassportUpload = async (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        try {
+            const { data: { text } } = await Tesseract.recognize(file, 'eng');
+            const lines = text.split('\n').map(l => l.trim()).filter(Boolean).slice(-2).join('');
+            const result = parse(lines);
+            const fields = result.fields;
+            setFormData(data => ({
+                ...data,
+                personalInfo: {
+                    ...data.personalInfo,
+                    fullName: `${fields.lastName.replace(/</g,' ')} ${fields.firstName.replace(/</g,' ')}`.trim(),
+                    firstNameEn: fields.firstName.replace(/</g,' '),
+                    lastNameEn: fields.lastName.replace(/</g,' '),
+                    dob: formatDate(fields.dateOfBirth),
+                    passportExpiry: formatDate(fields.expirationDate)
+                }
+            }));
+        } catch(err) {
+            console.error(err);
+        }
+    };
+
+    const formatDate = (val) => {
+        if (!val) return '';
+        const year = val.slice(0,2);
+        const month = val.slice(2,4);
+        const day = val.slice(4,6);
+        return `20${year}-${month}-${day}`;
+    };
     return (
         <div className="form-page">
             <header className="header docs-header">
@@ -25,10 +61,10 @@ const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
             <main className="form-main">
                 <h2 className="form-title">{t(title.toLowerCase(), language)}</h2>
                 <div className="docs-grid">
-                    <div className="upload-box"><p>Approved National ID</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>Passport Photo</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>Account Opening Letter from Employer</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
-                    <div className="upload-box"><p>Recent Personal Photo</p><div className="upload-placeholder"><input type="file" accept="image/*" capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('approvedNationalId', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('passportPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required onChange={handlePassportUpload} capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('accountOpeningLetter', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('recentPersonalPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
                 </div>
                 <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>
             </main>

--- a/src/contexts/FormContext.js
+++ b/src/contexts/FormContext.js
@@ -1,0 +1,13 @@
+import React, { useState, createContext, useContext } from 'react';
+
+const FormContext = createContext();
+export const useFormData = () => useContext(FormContext);
+
+export const FormProvider = ({ children }) => {
+  const [formData, setFormData] = useState({});
+  return (
+    <FormContext.Provider value={{ formData, setFormData }}>
+      {children}
+    </FormContext.Provider>
+  );
+};

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -58,6 +58,17 @@ const translations = {
   certifyCorrect: { en: 'I certify that all data entered is correct.', ar: 'أقر بأن جميع البيانات المدخلة صحيحة.' },
   agreeTerms: { en: 'I agree to the Terms and Conditions.', ar: 'أوافق على الشروط والأحكام.' },
   censusCardPhoto: { en: 'Census Card Photo', ar: 'صورة من بطاقة الحصر' },
+  approvedNationalId: { en: 'Approved National ID', ar: 'صورة بطاقة الهوية' },
+  passportPhoto: { en: 'Passport Photo', ar: 'صورة جواز السفر' },
+  accountOpeningLetter: { en: 'Account Opening Letter from Employer', ar: 'خطاب فتح حساب من جهة العمل' },
+  recentPersonalPhoto: { en: 'Recent Personal Photo', ar: 'صورة شخصية حديثة' },
+  bankStatement: { en: 'Bank statement for the last months (if any)', ar: 'كشف حساب مصرفي للأشهر الماضية (إن وجد)' },
+  taxCard: { en: 'Tax Card or Certificate', ar: 'بطاقة أو شهادة ضريبية' },
+  commercialChamberCertificate: { en: 'Commercial Chamber Registration Certificate', ar: 'شهادة قيد بالغرفة التجارية' },
+  legalRepAuth: { en: 'Official authorization for the legal representative', ar: 'تفويض رسمي للممثل القانوني' },
+  commercialRegisterCopy: { en: 'Copy of the Commercial Register', ar: 'نسخة من السجل التجاري' },
+  nationalIdPhotos: { en: 'Photos of National ID or Passport for authorized signatories', ar: 'صور للهوية أو جواز السفر للمخولين بالتوقيع' },
+  personalPhotos: { en: 'Recent personal photos for authorized signatories', ar: 'صور شخصية حديثة للمخولين بالتوقيع' },
   confirmData: { en: 'Please confirm your information', ar: 'يرجى تأكيد المعلومات المدخلة' },
   confirm: { en: 'Confirm', ar: 'تأكيد' }
 };


### PR DESCRIPTION
## Summary
- add new FormContext for sharing form data
- support automatic personal info from passport uploads
- require docs upload and translate descriptions
- export confirmation data to PDF

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686878835cec832f96c1c82b3ef5998b