### PR TITLE
Fix syntax error in PersonalInfoPage_EN

### DIFF
--- a/src/accountOpening/PersonalInfoPage_EN.js
+++ b/src/accountOpening/PersonalInfoPage_EN.js
@@ -37,20 +37,6 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow, state }) => {
             setForm(f => ({ ...f, ...formData.personalInfo }));
         }
     }, [formData.personalInfo]);
-        fullName: '',
-        firstNameEn: '',
-        middleNameEn: '',
-        lastNameEn: '',
-        dob: '',
-        gender: '',
-        nationality: '',
-        nidDigits: Array(12).fill(''),
-        phone: '',
-        enableEmail: false,
-        email: '',
-        residenceExpiry: '',
-        censusCardNumber: ''
-    });
 
     const [agreements, setAgreements] = useState({ agree1: false, agree2: false });
 


### PR DESCRIPTION
## Summary
- remove duplicated object definition in PersonalInfoPage_EN causing parser failure

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68687b5451d0832f860da96f795a699e