### PR TITLE
Add passport data extraction and validation

### DIFF
--- a/src/accountOpening/ConfirmPage_EN.js
+++ b/src/accountOpening/ConfirmPage_EN.js
@@ -46,9 +46,9 @@ const ConfirmPage_EN = ({ onNavigate, state }) => {
                 </div>
             </header>
             <main className="form-main">
-                <div className="form-section">
-                    <h3>{t('confirmData', language)}</h3>
-                    <ul style={{ listStyle: 'none', padding: 0 }}>
+                <div className="confirmation-document">
+                    <div className="confirmation-header">{t('confirmData', language)}</div>
+                    <ul className="confirmation-list">
                         <li><strong>{t('fullName', language)}:</strong> {form.fullName}</li>
                         <li><strong>{t('firstNameEn', language)}:</strong> {form.firstNameEn}</li>
                         <li><strong>{t('middleNameEn', language)}:</strong> {form.middleNameEn}</li>
@@ -56,6 +56,9 @@ const ConfirmPage_EN = ({ onNavigate, state }) => {
                         <li><strong>{t('dateOfBirth', language)}:</strong> {form.dob}</li>
                         <li><strong>{t('gender', language)}:</strong> {form.gender}</li>
                         <li><strong>{t('nationality', language)}:</strong> {form.nationality}</li>
+                        {form.documentType && (
+                            <li><strong>{t('documentType', language)}:</strong> {form.documentType}</li>
+                        )}
                         {form.nidDigits && (
                             <li><strong>{t('nid', language)}:</strong> {form.nidDigits.join('')}</li>
                         )}

--- a/src/accountOpening/ExpatDocsPage_EN.js
+++ b/src/accountOpening/ExpatDocsPage_EN.js
@@ -25,6 +25,7 @@ const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
                 ...data,
                 personalInfo: {
                     ...data.personalInfo,
+                    documentType: 'Passport',
                     fullName: `${fields.lastName.replace(/</g,' ')} ${fields.firstName.replace(/</g,' ')}`.trim(),
                     firstNameEn: fields.firstName.replace(/</g,' '),
                     lastNameEn: fields.lastName.replace(/</g,' '),

--- a/src/accountOpening/PersonalInfoPage_EN.js
+++ b/src/accountOpening/PersonalInfoPage_EN.js
@@ -26,7 +26,8 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow, state }) => {
             enableEmail: false,
             email: '',
             residenceExpiry: '',
-            censusCardNumber: ''
+            censusCardNumber: '',
+            documentType: ''
         },
         ...(formData.personalInfo || {}),
         ...(state?.form || {})
@@ -51,6 +52,15 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow, state }) => {
             digits[index] = value.replace(/[^0-9]/g, '').slice(-1);
             setForm(f => ({ ...f, nidDigits: digits }));
             if (value && e.target.nextSibling) e.target.nextSibling.focus();
+        } else if (name === 'fullName') {
+            const arabic = value.replace(/[^\u0600-\u06FF\s]/g, '');
+            setForm(f => ({ ...f, fullName: arabic }));
+        } else if (['firstNameEn', 'middleNameEn', 'lastNameEn'].includes(name)) {
+            const eng = value.replace(/[^A-Za-z\s]/g, '');
+            setForm(f => ({ ...f, [name]: eng }));
+        } else if (name === 'phone') {
+            const digits = value.replace(/[^0-9+]/g, '');
+            setForm(f => ({ ...f, phone: digits }));
         } else {
             setForm(f => ({ ...f, [name]: value }));
         }
@@ -92,6 +102,14 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow, state }) => {
     };
 
     const handleSubmit = () => {
+        const arabicRegex = /^[\u0600-\u06FF\s]+$/;
+        const englishRegex = /^[A-Za-z\s]+$/;
+        const phoneRegex = /^(\+218|218|0)?9\d{8}$/;
+        if (!arabicRegex.test(form.fullName)) { alert('Full name must be in Arabic'); return; }
+        if (!englishRegex.test(form.firstNameEn) ||
+            !englishRegex.test(form.middleNameEn) ||
+            !englishRegex.test(form.lastNameEn)) { alert('English names must contain only letters'); return; }
+        if (!phoneRegex.test(form.phone)) { alert('Invalid Libyan phone number'); return; }
         if (!validateNID()) { alert('Invalid National ID'); return; }
         if (!agreements.agree1 || !agreements.agree2) { alert('You must agree to proceed'); return; }
         setFormData(data => ({ ...data, personalInfo: form }));

--- a/src/accountOpening/SimpleDocsPage_EN.js
+++ b/src/accountOpening/SimpleDocsPage_EN.js
@@ -26,6 +26,7 @@ const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
                 ...data,
                 personalInfo: {
                     ...data.personalInfo,
+                    documentType: 'Passport',
                     fullName: `${fields.lastName.replace(/</g,' ')} ${fields.firstName.replace(/</g,' ')}`.trim(),
                     firstNameEn: fields.firstName.replace(/</g,' '),
                     lastNameEn: fields.lastName.replace(/</g,' '),

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -37,6 +37,7 @@ const translations = {
   libyan: { en: 'Libyan', ar: 'ليبي' },
   other: { en: 'Other', ar: 'أخرى' },
   nid: { en: 'National ID', ar: 'الرقم الوطني' },
+  documentType: { en: 'Document Type', ar: 'نوع المستند' },
   phoneNumber: { en: 'Phone Number', ar: 'رقم الهاتف' },
   enableEmail: { en: 'Enable Email', ar: 'تفعيل البريد الإلكتروني' },
   email: { en: 'Email', ar: 'البريد الإلكتروني' },

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -340,6 +340,19 @@ const GlobalStyles = () => (
         margin-top: auto;
     }
     .footer-transparent { background-color: transparent; }
+
+    /* ---=== Confirmation Document ===--- */
+    .confirmation-document {
+        background-color: var(--form-input-bg);
+        border: 2px solid var(--primary-color);
+        padding: 40px;
+        max-width: 700px;
+        margin: 0 auto 30px auto;
+        border-radius: 10px;
+    }
+    .confirmation-header { text-align: center; font-size: 1.8rem; font-weight: 700; margin-bottom: 20px; }
+    .confirmation-list { list-style: none; padding: 0; font-size: 1.1rem; }
+    .confirmation-list li { margin-bottom: 8px; }
     
     /* ---=== Success Page ===--- */
     .success-page {


### PR DESCRIPTION
## Summary
- capture document type when passport is scanned
- restrict name inputs by language and validate Libyan phone numbers
- show document type on confirmation page
- style confirmation page as an official document

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687decad54832fa28d9e9364c265a7