### PR TITLE
Add OCR module and integrate passport parsing

### DIFF
--- a/src/accountOpening/ExpatDocsPage_EN.js
+++ b/src/accountOpening/ExpatDocsPage_EN.js
@@ -6,8 +6,7 @@ import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useFormData } from '../contexts/FormContext';
-import Tesseract from 'tesseract.js';
-import { parse } from 'mrz';
+import { extractPassportData } from '../utils/ocr';
 
 const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
     const { language } = useLanguage();
@@ -17,31 +16,19 @@ const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
         const file = e.target.files[0];
         if (!file) return;
         try {
-            const { data: { text } } = await Tesseract.recognize(file, 'eng');
-            const lines = text.split('\n').map(l => l.trim()).filter(Boolean).slice(-2).join('');
-            const result = parse(lines);
-            const fields = result.fields;
-            setFormData(data => ({
-                ...data,
-                personalInfo: {
-                    ...data.personalInfo,
-                    documentType: 'Passport',
-                    fullName: `${fields.lastName.replace(/</g,' ')} ${fields.firstName.replace(/</g,' ')}`.trim(),
-                    firstNameEn: fields.firstName.replace(/</g,' '),
-                    lastNameEn: fields.lastName.replace(/</g,' '),
-                    dob: formatDate(fields.dateOfBirth),
-                    passportExpiry: formatDate(fields.expirationDate)
-                }
-            }));
-        } catch(err) { console.error(err); }
-    };
-
-    const formatDate = (val) => {
-        if (!val) return '';
-        const year = val.slice(0,2);
-        const month = val.slice(2,4);
-        const day = val.slice(4,6);
-        return `20${year}-${month}-${day}`;
+            const info = await extractPassportData(file);
+            if (info) {
+                setFormData(data => ({
+                    ...data,
+                    personalInfo: {
+                        ...data.personalInfo,
+                        ...info
+                    }
+                }));
+            }
+        } catch (err) {
+            console.error(err);
+        }
     };
     return (
         <div className="form-page">

--- a/src/accountOpening/SimpleDocsPage_EN.js
+++ b/src/accountOpening/SimpleDocsPage_EN.js
@@ -7,8 +7,7 @@ import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useFormData } from '../contexts/FormContext';
-import Tesseract from 'tesseract.js';
-import { parse } from 'mrz';
+import { extractPassportData } from '../utils/ocr';
 
 const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
     const { language } = useLanguage();
@@ -18,33 +17,19 @@ const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
         const file = e.target.files[0];
         if (!file) return;
         try {
-            const { data: { text } } = await Tesseract.recognize(file, 'eng');
-            const lines = text.split('\n').map(l => l.trim()).filter(Boolean).slice(-2).join('');
-            const result = parse(lines);
-            const fields = result.fields;
-            setFormData(data => ({
-                ...data,
-                personalInfo: {
-                    ...data.personalInfo,
-                    documentType: 'Passport',
-                    fullName: `${fields.lastName.replace(/</g,' ')} ${fields.firstName.replace(/</g,' ')}`.trim(),
-                    firstNameEn: fields.firstName.replace(/</g,' '),
-                    lastNameEn: fields.lastName.replace(/</g,' '),
-                    dob: formatDate(fields.dateOfBirth),
-                    passportExpiry: formatDate(fields.expirationDate)
-                }
-            }));
-        } catch(err) {
+            const info = await extractPassportData(file);
+            if (info) {
+                setFormData(data => ({
+                    ...data,
+                    personalInfo: {
+                        ...data.personalInfo,
+                        ...info
+                    }
+                }));
+            }
+        } catch (err) {
             console.error(err);
         }
-    };
-
-    const formatDate = (val) => {
-        if (!val) return '';
-        const year = val.slice(0,2);
-        const month = val.slice(2,4);
-        const day = val.slice(4,6);
-        return `20${year}-${month}-${day}`;
     };
     return (
         <div className="form-page">

--- a/src/utils/ocr.js
+++ b/src/utils/ocr.js
@@ -1,0 +1,41 @@
+import Tesseract from 'tesseract.js';
+import { parse } from 'mrz';
+
+export async function extractTextFromImage(file, lang = 'eng') {
+  if (!file) return '';
+  const { data: { text } } = await Tesseract.recognize(file, lang);
+  return text;
+}
+
+export async function extractPassportData(file) {
+  const text = await extractTextFromImage(file, 'eng');
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean)
+    .slice(-2)
+    .join('');
+  let result;
+  try {
+    result = parse(lines);
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
+  const fields = result.fields;
+  const formatDate = val => {
+    if (!val) return '';
+    const year = val.slice(0, 2);
+    const month = val.slice(2, 4);
+    const day = val.slice(4, 6);
+    return `20${year}-${month}-${day}`;
+  };
+  return {
+    documentType: 'Passport',
+    fullName: `${fields.lastName.replace(/</g, ' ')} ${fields.firstName.replace(/</g, ' ')}`.trim(),
+    firstNameEn: fields.firstName.replace(/</g, ' '),
+    lastNameEn: fields.lastName.replace(/</g, ' '),
+    dob: formatDate(fields.dateOfBirth),
+    passportExpiry: formatDate(fields.expirationDate)
+  };
+}


### PR DESCRIPTION
## Summary
- create `ocr` utility for text extraction and passport MRZ parsing
- use OCR utility in `ExpatDocsPage_EN` and `SimpleDocsPage_EN`
- populate personal info from extracted passport data

## Testing
- `npm install --silent` *(fails: command not found or network restricted)*
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686884034010832fa0876c8a3514ad7a