### PR TITLE
Add document verification checklist and passport OCR display

### DIFF
--- a/src/accountOpening/ExpatDocsPage_EN.js
+++ b/src/accountOpening/ExpatDocsPage_EN.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
 import ThemeSwitcher from '../common/ThemeSwitcher';
 import LanguageSwitcher from '../common/LanguageSwitcher';
@@ -11,13 +11,24 @@ import { extractPassportData } from '../utils/ocr';
 const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
     const { language } = useLanguage();
     const { setFormData } = useFormData();
+    const [uploaded, setUploaded] = useState({
+        passport: false,
+        letter: false,
+        photo: false,
+        census: false
+    });
+    const [passportInfo, setPassportInfo] = useState(null);
+    const [verifying, setVerifying] = useState(false);
+    const [verified, setVerified] = useState(false);
 
     const handlePassportUpload = async (e) => {
         const file = e.target.files[0];
         if (!file) return;
+        setVerifying(true);
         try {
             const info = await extractPassportData(file);
             if (info) {
+                setPassportInfo(info);
                 setFormData(data => ({
                     ...data,
                     personalInfo: {
@@ -25,11 +36,22 @@ const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
                         ...info
                     }
                 }));
+                setUploaded(u => ({ ...u, passport: true }));
             }
         } catch (err) {
             console.error(err);
+        } finally {
+            setVerifying(false);
         }
     };
+
+    const handleUpload = (key) => (e) => {
+        if (e.target.files[0]) {
+            setUploaded(u => ({ ...u, [key]: true }));
+        }
+    };
+
+    const allUploaded = passportInfo && Object.values(uploaded).every(Boolean);
     return (
         <div className="form-page">
             <header className="header docs-header">
@@ -46,12 +68,24 @@ const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
             <main className="form-main">
                 <h2 className="form-title">{t('requiredDocs', language)}</h2>
                 <div className="docs-grid">
-                    <div className="upload-box"><p>{t('passportPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required onChange={handlePassportUpload} capture="environment" /></div></div>
-                    <div className="upload-box"><p>{t('accountOpeningLetter', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
-                    <div className="upload-box"><p>{t('recentPersonalPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
-                    <div className="upload-box"><p>{t('censusCardPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('passportPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required onChange={handlePassportUpload} capture="environment" disabled={verifying} /></div></div>
+                    <div className="upload-box"><p>{t('accountOpeningLetter', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" onChange={handleUpload('letter')} disabled={verifying} /></div></div>
+                    <div className="upload-box"><p>{t('recentPersonalPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" onChange={handleUpload('photo')} disabled={verifying} /></div></div>
+                    <div className="upload-box"><p>{t('censusCardPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" onChange={handleUpload('census')} disabled={verifying} /></div></div>
                 </div>
-                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>
+                <ul className="upload-checklist">
+                    <li><input type="checkbox" readOnly checked={uploaded.passport} /> {t('passportPhoto', language)}</li>
+                    <li><input type="checkbox" readOnly checked={uploaded.letter} /> {t('accountOpeningLetter', language)}</li>
+                    <li><input type="checkbox" readOnly checked={uploaded.photo} /> {t('recentPersonalPhoto', language)}</li>
+                    <li><input type="checkbox" readOnly checked={uploaded.census} /> {t('censusCardPhoto', language)}</li>
+                </ul>
+                {passportInfo && (
+                    <textarea className="passport-info" readOnly value={`Name: ${passportInfo.fullName}\nBirth Date: ${passportInfo.dob}\nExpiry Date: ${passportInfo.passportExpiry}`} />
+                )}
+                <div className="form-actions">
+                    <button className="btn-next" onClick={() => setVerified(true)} disabled={!allUploaded || verifying}>Upload</button>
+                    <button className="btn-next" onClick={() => onNavigate(nextPage)} disabled={!verified || verifying}>{t('next', language)}</button>
+                </div>
             </main>
             <Footer />
         </div>

--- a/src/accountOpening/SimpleDocsPage_EN.js
+++ b/src/accountOpening/SimpleDocsPage_EN.js
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useState } from 'react';
 import { LOGO_WHITE } from '../assets/imagePaths';
 import ThemeSwitcher from '../common/ThemeSwitcher';
 import LanguageSwitcher from '../common/LanguageSwitcher';
@@ -12,13 +12,24 @@ import { extractPassportData } from '../utils/ocr';
 const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
     const { language } = useLanguage();
     const { setFormData } = useFormData();
+    const [uploaded, setUploaded] = useState({
+        nationalId: false,
+        passport: false,
+        letter: false,
+        photo: false
+    });
+    const [passportInfo, setPassportInfo] = useState(null);
+    const [verifying, setVerifying] = useState(false);
+    const [verified, setVerified] = useState(false);
 
     const handlePassportUpload = async (e) => {
         const file = e.target.files[0];
         if (!file) return;
+        setVerifying(true);
         try {
             const info = await extractPassportData(file);
             if (info) {
+                setPassportInfo(info);
                 setFormData(data => ({
                     ...data,
                     personalInfo: {
@@ -26,11 +37,22 @@ const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
                         ...info
                     }
                 }));
+                setUploaded(u => ({ ...u, passport: true }));
             }
         } catch (err) {
             console.error(err);
+        } finally {
+            setVerifying(false);
         }
     };
+
+    const handleUpload = (key) => (e) => {
+        if (e.target.files[0]) {
+            setUploaded(u => ({ ...u, [key]: true }));
+        }
+    };
+
+    const allUploaded = passportInfo && Object.values(uploaded).every(Boolean);
     return (
         <div className="form-page">
             <header className="header docs-header">
@@ -47,12 +69,24 @@ const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
             <main className="form-main">
                 <h2 className="form-title">{t(title.toLowerCase(), language)}</h2>
                 <div className="docs-grid">
-                    <div className="upload-box"><p>{t('approvedNationalId', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
-                    <div className="upload-box"><p>{t('passportPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required onChange={handlePassportUpload} capture="environment" /></div></div>
-                    <div className="upload-box"><p>{t('accountOpeningLetter', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
-                    <div className="upload-box"><p>{t('recentPersonalPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('approvedNationalId', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" onChange={handleUpload('nationalId')} disabled={verifying} /></div></div>
+                    <div className="upload-box"><p>{t('passportPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required onChange={handlePassportUpload} capture="environment" disabled={verifying} /></div></div>
+                    <div className="upload-box"><p>{t('accountOpeningLetter', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" onChange={handleUpload('letter')} disabled={verifying} /></div></div>
+                    <div className="upload-box"><p>{t('recentPersonalPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" onChange={handleUpload('photo')} disabled={verifying} /></div></div>
                 </div>
-                <div className="form-actions"><button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button></div>
+                <ul className="upload-checklist">
+                    <li><input type="checkbox" readOnly checked={uploaded.nationalId} /> {t('approvedNationalId', language)}</li>
+                    <li><input type="checkbox" readOnly checked={uploaded.passport} /> {t('passportPhoto', language)}</li>
+                    <li><input type="checkbox" readOnly checked={uploaded.letter} /> {t('accountOpeningLetter', language)}</li>
+                    <li><input type="checkbox" readOnly checked={uploaded.photo} /> {t('recentPersonalPhoto', language)}</li>
+                </ul>
+                {passportInfo && (
+                    <textarea className="passport-info" readOnly value={`Name: ${passportInfo.fullName}\nBirth Date: ${passportInfo.dob}\nExpiry Date: ${passportInfo.passportExpiry}`} />
+                )}
+                <div className="form-actions">
+                    <button className="btn-next" onClick={() => setVerified(true)} disabled={!allUploaded || verifying}>Upload</button>
+                    <button className="btn-next" onClick={() => onNavigate(nextPage)} disabled={!verified || verifying}>{t('next', language)}</button>
+                </div>
             </main>
             <Footer />
         </div>

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -318,6 +318,9 @@ const GlobalStyles = () => (
     body[dir="ltr"] .date-input-container svg { right: 15px; }
     .national-id-group { display: flex; gap: 10px; justify-content: space-between; }
     .national-id-input { width: 40px; height: 50px; text-align: center; font-size: 1.5rem; border: 1px solid #ccc; border-radius: 8px; background-color: var(--form-input-bg); color: var(--form-input-text); }
+    .upload-checklist { list-style: none; padding: 0; margin-bottom: 20px; width: 100%; max-width: 600px; }
+    .upload-checklist li { display: flex; align-items: center; gap: 10px; margin-bottom: 5px; font-weight: 600; color: var(--text-color-dark); }
+    .passport-info { width: 100%; max-width: 600px; height: 100px; margin-bottom: 20px; padding: 10px; border: 1px solid #ccc; border-radius: 8px; background-color: var(--form-input-bg); color: var(--form-input-text); box-sizing: border-box; }
     .agreements { width: 100%; max-width: 600px; margin-bottom: 20px; }
     .agreement-item { display: flex; align-items: center; gap: 15px; font-size: 1.1rem; font-weight: 600; color: var(--text-color-dark); }
     .agreement-item:first-child { margin-bottom: 15px; }


### PR DESCRIPTION
## Summary
- show upload checklist for document pages
- display extracted passport info from OCR
- disable Upload/Next buttons until verification is complete
- style checklist and passport info box

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68690917c51c832fbdc80b4158268a85