### PR TITLE
Add sequential document upload extraction

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,7 @@ import FinancialInfoPage_EN from './accountOpening/FinancialInfoPage_EN';
 import SuccessPage_EN from './accountOpening/SuccessPage_EN';
 import ConfirmPage_EN from './accountOpening/ConfirmPage_EN';
 import EServicesLanding from './eServices/EServicesLandingPage';
+import SequentialDocsPage_EN from './accountOpening/SequentialDocsPage_EN';
 
 
 // ---=== Main App Component ===---
@@ -66,6 +67,7 @@ const AppContent = () => {
             case 'expatDocs': return <ExpatDocsPage_EN onNavigate={handleNavigation} backPage="selectUser" nextPage="contactInfo" />;
 
             case 'companiesDocs': return <CompaniesDocsPage_EN onNavigate={handleNavigation} backPage="selectUser" nextPage="companyInfo" />;
+            case 'sequentialDocs': return <SequentialDocsPage_EN onNavigate={handleNavigation} backPage="selectUser" nextPage="contactInfo" />;
             case 'companyInfo': return <CompanyInfoPage_EN onNavigate={handleNavigation} backPage="companiesDocs" nextPage="companyContact" />;
             case 'companyContact': return <CompanyContactPage_EN onNavigate={handleNavigation} backPage="companyInfo" nextPage="legalRepInfo" />;
             case 'legalRepInfo': return <LegalRepInfoPage_EN onNavigate={handleNavigation} backPage="companyContact" nextPage="financialInfo" />;

--- a/src/accountOpening/SequentialDocsPage_EN.js
+++ b/src/accountOpening/SequentialDocsPage_EN.js
@@ -1,0 +1,94 @@
+import React, { useState, useRef } from 'react';
+import { extractDocumentData } from '../utils/docExtractor';
+import { t } from '../i18n';
+import ThemeSwitcher from '../common/ThemeSwitcher';
+import LanguageSwitcher from '../common/LanguageSwitcher';
+import Footer from '../common/Footer';
+import { LOGO_WHITE } from '../assets/imagePaths';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const DOCS = [
+  { key: 'passport', labelKey: 'passportPhoto' },
+  { key: 'nationalId', labelKey: 'approvedNationalId' },
+  { key: 'letter', labelKey: 'accountOpeningLetter' },
+  { key: 'photo', labelKey: 'recentPersonalPhoto' },
+];
+
+const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
+  const { language } = useLanguage();
+  const [current, setCurrent] = useState(0);
+  const [data, setData] = useState({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const fileInputRef = useRef(null);
+
+  const handleUpload = async (file) => {
+    if (!file) return;
+    setIsLoading(true);
+    setError('');
+    try {
+      const result = await extractDocumentData(file, DOCS[current].key);
+      setData((d) => ({ ...d, [DOCS[current].key]: result }));
+    } catch (e) {
+      console.error(e);
+      setError('Failed to extract data');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleConfirm = () => {
+    setCurrent((c) => c + 1);
+  };
+
+  const allDone = current >= DOCS.length;
+  const doc = DOCS[current];
+
+  return (
+    <div className="form-page">
+      <header className="header docs-header">
+        <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
+        <div style={{ display: 'flex', gap: '30px' }}>
+          <ThemeSwitcher />
+          <LanguageSwitcher />
+        </div>
+        <button onClick={() => onNavigate(backPage)} className="btn-back">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+          <span>{t('back', language)}</span>
+        </button>
+      </header>
+      <main className="form-main" style={{ textAlign: 'center' }}>
+        {allDone ? (
+          <>
+            <h2 className="form-title">{t('confirmData', language)}</h2>
+            <pre style={{ textAlign: 'left' }}>{JSON.stringify(data, null, 2)}</pre>
+            <div className="form-actions">
+              <button className="btn-next" onClick={() => onNavigate(nextPage)}>{t('next', language)}</button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="form-title">{t(doc.labelKey, language)}</h2>
+            <div className="upload-box" onClick={() => fileInputRef.current.click()}>
+              <div className="upload-placeholder">
+                <input type="file" ref={fileInputRef} onChange={(e) => handleUpload(e.target.files[0])} accept="image/*" style={{ display: 'none' }} />
+                <span style={{ cursor: 'pointer' }}>{t('upload_prompt', language)}</span>
+              </div>
+            </div>
+            {isLoading && <p>{t('extracting_data', language)}</p>}
+            {error && <p className="error-message">{error}</p>}
+            {data[doc.key] && !isLoading && (
+              <div className="status-dialog" style={{ textAlign: 'left' }}>
+                <pre>{JSON.stringify(data[doc.key], null, 2)}</pre>
+                <button className="btn-next" onClick={handleConfirm}>{t('confirm', language)}</button>
+              </div>
+            )}
+          </>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default SequentialDocsPage_EN;

--- a/src/utils/docExtractor.js
+++ b/src/utils/docExtractor.js
@@ -1,0 +1,84 @@
+import { t } from '../i18n';
+
+// Convert a file to base64 string
+const fileToBase64 = (file) => new Promise((resolve, reject) => {
+  const reader = new FileReader();
+  reader.onloadend = () => resolve(reader.result.split(',')[1]);
+  reader.onerror = reject;
+  reader.readAsDataURL(file);
+});
+
+const passportSchema = {
+  type: 'OBJECT',
+  properties: {
+    fullNameArabic: { type: 'STRING' },
+    firstNameEng: { type: 'STRING' },
+    midNameEng: { type: 'STRING' },
+    surnameEng: { type: 'STRING' },
+    passportNo: { type: 'STRING' },
+    dateOfBirth: { type: 'STRING' },
+    placeOfBirth: { type: 'STRING' },
+    dateOfIssue: { type: 'STRING' },
+    issuingPlace: { type: 'STRING' },
+    sex: { type: 'STRING' },
+    nationality: { type: 'STRING' },
+    expiryDate: { type: 'STRING' },
+  },
+};
+
+const genericSchema = { type: 'OBJECT' };
+
+const DOC_CONFIGS = {
+  passport: {
+    instruction: `Extract the following fields from the passport image: ${Object.keys(passportSchema.properties).join(', ')}. Return the data in the specified JSON format.`,
+    schema: passportSchema,
+  },
+  nationalId: {
+    instruction: 'Extract any readable fields from the National ID image in JSON format.',
+    schema: genericSchema,
+  },
+  letter: {
+    instruction: 'Extract any structured data from this letter image in JSON format.',
+    schema: genericSchema,
+  },
+  photo: {
+    instruction: 'Describe the person in the photo in JSON format with a single field "description".',
+    schema: { type: 'OBJECT', properties: { description: { type: 'STRING' } } },
+  },
+};
+
+export async function extractDocumentData(file, docType) {
+  const config = DOC_CONFIGS[docType] || DOC_CONFIGS.passport;
+  const base64Data = await fileToBase64(file);
+  const payload = {
+    contents: [{
+      parts: [
+        { text: config.instruction },
+        { inlineData: { mimeType: file.type || 'image/png', data: base64Data } },
+      ],
+    }],
+    generationConfig: {
+      responseMimeType: 'application/json',
+      responseSchema: config.schema,
+    },
+  };
+
+  const apiKey = '';
+  const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
+
+  const resp = await fetch(apiUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  const result = await resp.json();
+  if (result.candidates && result.candidates[0].content.parts[0].text) {
+    try {
+      return JSON.parse(result.candidates[0].content.parts[0].text);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add generic document data extraction helper
- add page for sequential document uploads and confirmations
- wire new page into the app

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686914a39d10832fa6fe4cf37b46f3c3