### PR TITLE
Improve sequential docs page with image preview

### DIFF
--- a/src/accountOpening/SequentialDocsPage_EN.js
+++ b/src/accountOpening/SequentialDocsPage_EN.js
@@ -4,6 +4,7 @@ import { t } from '../i18n';
 import ThemeSwitcher from '../common/ThemeSwitcher';
 import LanguageSwitcher from '../common/LanguageSwitcher';
 import Footer from '../common/Footer';
+import { UploadIcon } from '../common/Icons';
 import { LOGO_WHITE } from '../assets/imagePaths';
 import { useLanguage } from '../contexts/LanguageContext';
 
@@ -20,10 +21,32 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
   const [data, setData] = useState({});
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+  const [image, setImage] = useState(null);
+  const [isCopied, setIsCopied] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef(null);
+
+  const handleDragEvents = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === 'dragenter' || e.type === 'dragover') setIsDragging(true);
+    else if (e.type === 'dragleave') setIsDragging(false);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+      handleUpload(e.dataTransfer.files[0]);
+    }
+  };
 
   const handleUpload = async (file) => {
     if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => setImage(reader.result);
+    reader.readAsDataURL(file);
     setIsLoading(true);
     setError('');
     try {
@@ -37,8 +60,19 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
     }
   };
 
+  const handleCopy = () => {
+    if (!data[DOCS[current].key]) return;
+    const text = JSON.stringify(data[DOCS[current].key], null, 2);
+    navigator.clipboard.writeText(text);
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), 2000);
+  };
+
   const handleConfirm = () => {
     setCurrent((c) => c + 1);
+    setImage(null);
+    setIsCopied(false);
+    setError('');
   };
 
   const allDone = current >= DOCS.length;
@@ -69,18 +103,63 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
         ) : (
           <>
             <h2 className="form-title">{t(doc.labelKey, language)}</h2>
-            <div className="upload-box" onClick={() => fileInputRef.current.click()}>
-              <div className="upload-placeholder">
-                <input type="file" ref={fileInputRef} onChange={(e) => handleUpload(e.target.files[0])} accept="image/*" style={{ display: 'none' }} />
-                <span style={{ cursor: 'pointer' }}>{t('upload_prompt', language)}</span>
+            {!image && (
+              <div
+                className={`upload-area ${isDragging ? 'drag-over' : ''}`}
+                onClick={() => fileInputRef.current.click()}
+                onDragEnter={handleDragEvents}
+                onDragOver={handleDragEvents}
+                onDragLeave={handleDragEvents}
+                onDrop={handleDrop}
+              >
+                <input
+                  type="file"
+                  ref={fileInputRef}
+                  onChange={(e) => handleUpload(e.target.files[0])}
+                  accept="image/*"
+                  style={{ display: 'none' }}
+                />
+                <div className="upload-icon"><UploadIcon /></div>
+                <h2>{t('upload_prompt', language)}</h2>
               </div>
-            </div>
-            {isLoading && <p>{t('extracting_data', language)}</p>}
+            )}
+            {image && (
+              <div className="result-container">
+                <div className="image-preview-box">
+                  <img src={image} alt="preview" />
+                </div>
+                <div className="data-result-box">
+                  <div className="data-result-header">
+                    <h3>Extracted Data</h3>
+                    {data[doc.key] && !isLoading && (
+                      <button onClick={handleCopy} className="copy-btn">
+                        {isCopied ? 'Copied!' : 'Copy'}
+                      </button>
+                    )}
+                  </div>
+                  {isLoading && (
+                    <div style={{display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',height:'100%'}}>
+                      <div className="loading-spinner"></div>
+                      <p style={{marginTop:'20px'}}>{t('extracting_data', language)}</p>
+                    </div>
+                  )}
+                  {!isLoading && data[doc.key] && (
+                    <div className="data-result-content">
+                      {Object.keys(data[doc.key]).map((k) => (
+                        <div className="data-item" key={k}>
+                          <span className="data-label">{k}</span>
+                          <span className="data-value">{data[doc.key][k] || 'N/A'}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
             {error && <p className="error-message">{error}</p>}
             {data[doc.key] && !isLoading && (
-              <div className="status-dialog" style={{ textAlign: 'left' }}>
-                <pre>{JSON.stringify(data[doc.key], null, 2)}</pre>
-                <button className="btn-next" onClick={handleConfirm}>{t('confirm', language)}</button>
+              <div className="form-actions">
+                <button className="btn-next" onClick={handleConfirm}>{t('next', language)}</button>
               </div>
             )}
           </>

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -391,6 +391,29 @@ const GlobalStyles = () => (
         margin-bottom: 40px;
     }
 
+    /* ---=== Upload Extractor Styles ===--- */
+    .upload-area { width: 100%; max-width: 600px; background-color: var(--form-input-bg); border-radius: 15px; padding: 40px; text-align: center; border: 2px dashed #ccc; transition: all 0.3s ease; box-shadow: 0 5px 20px var(--shadow-color); }
+    .upload-area.drag-over { border-color: var(--primary-color); transform: scale(1.02); }
+    .upload-area .upload-icon { color: #ccc; margin-bottom: 20px; }
+    .upload-area h2 { margin: 0 0 10px 0; color: var(--text-color-dark); }
+    .upload-btn { background-color: var(--primary-color); color: white; border: none; padding: 12px 30px; font-size: 1rem; font-weight: 600; border-radius: 8px; cursor: pointer; transition: all 0.3s ease; }
+    .upload-btn:hover { background-color: var(--primary-dark); }
+    .result-container { display: flex; gap: 30px; width: 100%; max-width: 1200px; flex-grow: 1; min-height: 0; }
+    .image-preview-box, .data-result-box { background-color: var(--form-input-bg); border-radius: 15px; padding: 30px; box-shadow: 0 5px 20px var(--shadow-color); flex: 1; display: flex; flex-direction: column; }
+    .image-preview-box img { max-width: 100%; max-height: 100%; object-fit: contain; border-radius: 8px; }
+    .data-result-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
+    .data-result-header h3 { margin: 0; color: var(--text-color-dark); }
+    .copy-btn { background-color: var(--secondary-color); color: var(--text-color-dark); border: 1px solid #ccc; padding: 8px 12px; font-size: 0.9rem; font-weight: 600; border-radius: 8px; cursor: pointer; display: flex; align-items: center; gap: 8px; }
+    .data-result-content { flex-grow: 1; overflow-y: auto; }
+    .data-item { display: flex; justify-content: space-between; padding: 12px 8px; border-bottom: 1px solid var(--secondary-color); }
+    .data-item:last-child { border-bottom: none; }
+    .data-label { font-weight: 600; color: var(--text-color-dark); }
+    .data-value { color: var(--primary-dark); font-family: var(--font-primary-en); }
+    body[dir="rtl"] .data-value { font-family: var(--font-primary-ar); }
+    .loading-spinner { border: 4px solid #f3f3f3; border-top: 4px solid var(--primary-color); border-radius: 50%; width: 40px; height: 40px; animation: spin 1s linear infinite; }
+    @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+    .error-message { color: #e53e3e; font-weight: 600; background-color: rgba(229, 62, 62, 0.1); padding: 15px; border-radius: 8px; text-align: center; }
+
     /* ---=== RESPONSIVE ADJUSTMENTS ===--- */
     @media (max-width: 768px) {
         .header { padding: 10px 20px; }


### PR DESCRIPTION
## Summary
- enhance `SequentialDocsPage_EN` with drag/drop upload, image preview, copy button, and next step
- inject extractor-specific styles into `GlobalStyles`

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68691cd0f8b4832fb6e9b4a4294d3296