### PR TITLE
Add document extraction utilities

### DIFF
--- a/src/accountOpening/ExpatDocsPage_EN.js
+++ b/src/accountOpening/ExpatDocsPage_EN.js
@@ -6,8 +6,7 @@ import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useFormData } from '../contexts/FormContext';
-import Tesseract from 'tesseract.js';
-import { parse } from 'mrz';
+import { extractPassportData } from '../utils/Passport_Data_Extractor';
 
 const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
     const { language } = useLanguage();
@@ -15,51 +14,15 @@ const ExpatDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
 
     const handlePassportUpload = async (e) => {
         const file = e.target.files[0];
-        if (!file) return;
-        try {
-            const { data: { text } } = await Tesseract.recognize(file, 'ara+eng');
-            const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
-            const mrz = lines.slice(-2).join('');
-            const result = parse(mrz);
-            const f = result.fields;
-
-            const arabicLine = lines.find(l => /[\u0600-\u06FF]/.test(l)) || '';
-            const issueMatch = text.match(/(?:issue|issuance)[^\d]*(\d{2,4}[\/-]\d{1,2}[\/-]\d{2,4})/i);
-            const issueDate = issueMatch ? normalizeDate(issueMatch[1]) : '';
-
-            setFormData(data => ({
-                ...data,
-                personalInfo: {
-                    ...data.personalInfo,
-                    documentType: 'Passport',
-                    passportNumber: f.documentNumber,
-                    passportIssueDate: issueDate,
-                    passportExpiry: formatMRZDate(f.expirationDate),
-                    fullName: arabicLine || `${f.lastName.replace(/</g,' ')} ${f.firstName.replace(/</g,' ')}`.trim(),
-                    firstNameEn: f.firstName.replace(/</g,' '),
-                    lastNameEn: f.lastName.replace(/</g,' '),
-                    dob: formatMRZDate(f.birthDate)
-                }
-            }));
-        } catch(err) { console.error(err); }
-    };
-
-    const formatMRZDate = (val) => {
-        if (!val) return '';
-        const year = val.slice(0,2);
-        const month = val.slice(2,4);
-        const day = val.slice(4,6);
-        return `20${year}-${month}-${day}`;
-    };
-
-    const normalizeDate = (val) => {
-        const digits = val.replace(/[^0-9]/g, '');
-        if (digits.length === 6) return `20${digits.slice(0,2)}-${digits.slice(2,4)}-${digits.slice(4,6)}`;
-        if (digits.length === 8) {
-            if (digits.startsWith('20')) return `${digits.slice(0,4)}-${digits.slice(4,6)}-${digits.slice(6,8)}`;
-            return `${digits.slice(4,8)}-${digits.slice(2,4)}-${digits.slice(0,2)}`;
-        }
-        return '';
+        const data = await extractPassportData(file);
+        if (!data) return;
+        setFormData(prev => ({
+            ...prev,
+            personalInfo: {
+                ...prev.personalInfo,
+                ...data
+            }
+        }));
     };
     return (
         <div className="form-page">

--- a/src/accountOpening/SimpleDocsPage_EN.js
+++ b/src/accountOpening/SimpleDocsPage_EN.js
@@ -7,8 +7,8 @@ import Footer from '../common/Footer';
 import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useFormData } from '../contexts/FormContext';
-import Tesseract from 'tesseract.js';
-import { parse } from 'mrz';
+import { extractPassportData } from '../utils/Passport_Data_Extractor';
+import { extractNIDData } from '../utils/NID_Data_Extractor';
 
 const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
     const { language } = useLanguage();
@@ -16,54 +16,30 @@ const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
 
     const handlePassportUpload = async (e) => {
         const file = e.target.files[0];
-        if (!file) return;
-        try {
-            const { data: { text } } = await Tesseract.recognize(file, 'ara+eng');
-            const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
-            const mrz = lines.slice(-2).join('');
-            const result = parse(mrz);
-            const f = result.fields;
-
-            const arabicLine = lines.find(l => /[\u0600-\u06FF]/.test(l)) || '';
-            const issueMatch = text.match(/(?:issue|issuance)[^\d]*(\d{2,4}[\/-]\d{1,2}[\/-]\d{2,4})/i);
-            const issueDate = issueMatch ? normalizeDate(issueMatch[1]) : '';
-
-            setFormData(data => ({
-                ...data,
-                personalInfo: {
-                    ...data.personalInfo,
-                    documentType: 'Passport',
-                    passportNumber: f.documentNumber,
-                    passportIssueDate: issueDate,
-                    passportExpiry: formatMRZDate(f.expirationDate),
-                    fullName: arabicLine || `${f.lastName.replace(/</g,' ')} ${f.firstName.replace(/</g,' ')}`.trim(),
-                    firstNameEn: f.firstName.replace(/</g,' '),
-                    lastNameEn: f.lastName.replace(/</g,' '),
-                    dob: formatMRZDate(f.birthDate)
-                }
-            }));
-        } catch(err) {
-            console.error(err);
-        }
+        const data = await extractPassportData(file);
+        if (!data) return;
+        setFormData(prev => ({
+            ...prev,
+            personalInfo: {
+                ...prev.personalInfo,
+                ...data
+            }
+        }));
     };
 
-    const formatMRZDate = (val) => {
-        if (!val) return '';
-        const year = val.slice(0,2);
-        const month = val.slice(2,4);
-        const day = val.slice(4,6);
-        return `20${year}-${month}-${day}`;
+    const handleNIDUpload = async (e) => {
+        const file = e.target.files[0];
+        const data = await extractNIDData(file);
+        if (!data) return;
+        setFormData(prev => ({
+            ...prev,
+            personalInfo: {
+                ...prev.personalInfo,
+                ...data
+            }
+        }));
     };
 
-    const normalizeDate = (val) => {
-        const digits = val.replace(/[^0-9]/g, '');
-        if (digits.length === 6) return `20${digits.slice(0,2)}-${digits.slice(2,4)}-${digits.slice(4,6)}`;
-        if (digits.length === 8) {
-            if (digits.startsWith('20')) return `${digits.slice(0,4)}-${digits.slice(4,6)}-${digits.slice(6,8)}`;
-            return `${digits.slice(4,8)}-${digits.slice(2,4)}-${digits.slice(0,2)}`;
-        }
-        return '';
-    };
     return (
         <div className="form-page">
             <header className="header docs-header">
@@ -80,7 +56,7 @@ const SimpleDocsPage_EN = ({ onNavigate, backPage, nextPage, title }) => {
             <main className="form-main">
                 <h2 className="form-title">{t(title.toLowerCase(), language)}</h2>
                 <div className="docs-grid">
-                    <div className="upload-box"><p>{t('approvedNationalId', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
+                    <div className="upload-box"><p>{t('approvedNationalId', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required onChange={handleNIDUpload} capture="environment" /></div></div>
                     <div className="upload-box"><p>{t('passportPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required onChange={handlePassportUpload} capture="environment" /></div></div>
                     <div className="upload-box"><p>{t('accountOpeningLetter', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>
                     <div className="upload-box"><p>{t('recentPersonalPhoto', language)}</p><div className="upload-placeholder"><input type="file" accept="image/*" required capture="environment" /></div></div>

--- a/src/utils/NID_Data_Extractor.js
+++ b/src/utils/NID_Data_Extractor.js
@@ -1,0 +1,15 @@
+import Tesseract from 'tesseract.js';
+
+export const extractNIDData = async (file) => {
+  if (!file) return null;
+  try {
+    const { data: { text } } = await Tesseract.recognize(file, 'ara+eng');
+    const digits = text.replace(/\D/g, '').slice(-12);
+    return { nidDigits: digits.split('') };
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
+};
+
+export default extractNIDData;

--- a/src/utils/Passport_Data_Extractor.js
+++ b/src/utils/Passport_Data_Extractor.js
@@ -1,0 +1,52 @@
+import Tesseract from 'tesseract.js';
+import { parse } from 'mrz';
+
+const formatMRZDate = (val) => {
+  if (!val) return '';
+  const year = val.slice(0, 2);
+  const month = val.slice(2, 4);
+  const day = val.slice(4, 6);
+  return `20${year}-${month}-${day}`;
+};
+
+const normalizeDate = (val) => {
+  const digits = val.replace(/[^0-9]/g, '');
+  if (digits.length === 6) return `20${digits.slice(0,2)}-${digits.slice(2,4)}-${digits.slice(4,6)}`;
+  if (digits.length === 8) {
+    if (digits.startsWith('20')) return `${digits.slice(0,4)}-${digits.slice(4,6)}-${digits.slice(6,8)}`;
+    return `${digits.slice(4,8)}-${digits.slice(2,4)}-${digits.slice(0,2)}`;
+  }
+  return '';
+};
+
+export const extractPassportData = async (file) => {
+  if (!file) return null;
+  try {
+    const { data: { text } } = await Tesseract.recognize(file, 'ara+eng');
+    const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
+    const mrz = lines.slice(-2).join('');
+    let fields = {};
+    try {
+      const result = parse(mrz);
+      fields = result.fields;
+    } catch {}
+    const arabicLine = lines.find(l => /[\u0600-\u06FF]/.test(l)) || '';
+    const issueMatch = text.match(/(?:issue|issuance)[^\d]*(\d{2,4}[\/-]\d{1,2}[\/-]\d{2,4})/i);
+    const issueDate = issueMatch ? normalizeDate(issueMatch[1]) : '';
+    return {
+      documentType: 'Passport',
+      passportNumber: fields.documentNumber || '',
+      passportIssueDate: issueDate,
+      passportExpiry: formatMRZDate(fields.expirationDate),
+      fullName: arabicLine || `${fields.lastName?.replace(/</g,' ')} ${fields.firstName?.replace(/</g,' ')}`.trim(),
+      firstNameEn: fields.firstName?.replace(/</g,' '),
+      lastNameEn: fields.lastName?.replace(/</g,' '),
+      dob: formatMRZDate(fields.birthDate)
+    };
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
+};
+
+export default extractPassportData;


### PR DESCRIPTION
## Summary
- add `Passport_Data_Extractor` and `NID_Data_Extractor` utilities
- use `extractPassportData` in Expat and Simple document pages
- use `extractNIDData` for national ID photo uploads

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692b2f847c832fab5b5d21168345f8