### PR TITLE
Cache non-passport documents

### DIFF
--- a/src/accountOpening/SequentialDocsPage_EN.js
+++ b/src/accountOpening/SequentialDocsPage_EN.js
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { extractDocumentData } from '../utils/docExtractor';
 import { extractPassportData, extractNIDData } from '../utils/passportNidExtractors';
+import { uploadDocument } from '../utils/fileUploader';
 import { t } from '../i18n';
 import ThemeSwitcher from '../common/ThemeSwitcher';
 import LanguageSwitcher from '../common/LanguageSwitcher';
@@ -57,7 +58,8 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
       } else if (DOCS[current].key === 'nationalId') {
         result = await extractNIDData(file);
       } else {
-        result = await extractDocumentData(file, DOCS[current].key);
+        await uploadDocument(file, DOCS[current].key);
+        result = { uploaded: true };
       }
       setData((d) => ({ ...d, [DOCS[current].key]: result }));
     } catch (e) {

--- a/src/utils/fileUploader.js
+++ b/src/utils/fileUploader.js
@@ -1,0 +1,16 @@
+export async function uploadDocument(file, docType) {
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('docType', docType);
+
+  const resp = await fetch('/api/cache-upload', {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!resp.ok) {
+    throw new Error('Upload failed');
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- create `uploadDocument` helper for sending files to `/api/cache-upload`
- call `uploadDocument` for letter and photo uploads instead of extracting data

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686935ae83f8832f84adac6db3ba561f