### PR TITLE
Update document upload handling

### DIFF
--- a/src/accountOpening/SequentialDocsPage_EN.js
+++ b/src/accountOpening/SequentialDocsPage_EN.js
@@ -55,6 +55,25 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
       let result;
       if (DOCS[current].key === 'passport') {
         result = await extractPassportData(file);
+        const fields = [
+          'fullNameArabic',
+          'firstNameEng',
+          'midNameEng',
+          'surnameEng',
+          'passportNo',
+          'dateOfBirth',
+          'placeOfBirth',
+          'dateOfIssue',
+          'issuingPlace',
+          'sex',
+          'nationality',
+          'expiryDate',
+        ];
+        const hasPassportData =
+          result && fields.some((f) => result[f]);
+        if (!hasPassportData) {
+          throw new Error('invalidPassport');
+        }
       } else if (DOCS[current].key === 'nationalId') {
         result = await extractNIDData(file);
       } else {
@@ -64,7 +83,11 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
       setData((d) => ({ ...d, [DOCS[current].key]: result }));
     } catch (e) {
       console.error(e);
-      setError('Failed to extract data');
+      if (DOCS[current].key === 'passport') {
+        setError(t('invalidPassport', language));
+      } else {
+        setError('Failed to extract data');
+      }
     } finally {
       setIsLoading(false);
     }
@@ -138,32 +161,34 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
                 <div className="image-preview-box">
                   <img src={image} alt="preview" />
                 </div>
-                <div className="data-result-box">
-                  <div className="data-result-header">
-                    <h3>Extracted Data</h3>
-                    {data[doc.key] && !isLoading && (
-                      <button onClick={handleCopy} className="copy-btn">
-                        {isCopied ? 'Copied!' : 'Copy'}
-                      </button>
+                {doc.key !== 'letter' && (
+                  <div className="data-result-box">
+                    <div className="data-result-header">
+                      <h3>Extracted Data</h3>
+                      {data[doc.key] && !isLoading && (
+                        <button onClick={handleCopy} className="copy-btn">
+                          {isCopied ? 'Copied!' : 'Copy'}
+                        </button>
+                      )}
+                    </div>
+                    {isLoading && (
+                      <div style={{display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',height:'100%'}}>
+                        <div className="loading-spinner"></div>
+                        <p style={{marginTop:'20px'}}>{t('extracting_data', language)}</p>
+                      </div>
+                    )}
+                    {!isLoading && data[doc.key] && (
+                      <div className="data-result-content">
+                        {Object.keys(data[doc.key]).map((k) => (
+                          <div className="data-item" key={k}>
+                            <span className="data-label">{k}</span>
+                            <span className="data-value">{data[doc.key][k] || 'N/A'}</span>
+                          </div>
+                        ))}
+                      </div>
                     )}
                   </div>
-                  {isLoading && (
-                    <div style={{display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',height:'100%'}}>
-                      <div className="loading-spinner"></div>
-                      <p style={{marginTop:'20px'}}>{t('extracting_data', language)}</p>
-                    </div>
-                  )}
-                  {!isLoading && data[doc.key] && (
-                    <div className="data-result-content">
-                      {Object.keys(data[doc.key]).map((k) => (
-                        <div className="data-item" key={k}>
-                          <span className="data-label">{k}</span>
-                          <span className="data-value">{data[doc.key][k] || 'N/A'}</span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                )}
               </div>
             )}
             {error && <p className="error-message">{error}</p>}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -71,7 +71,10 @@ const translations = {
   nationalIdPhotos: { en: 'Photos of National ID or Passport for authorized signatories', ar: 'صور للهوية أو جواز السفر للمخولين بالتوقيع' },
   personalPhotos: { en: 'Recent personal photos for authorized signatories', ar: 'صور شخصية حديثة للمخولين بالتوقيع' },
   confirmData: { en: 'Please confirm your information', ar: 'يرجى تأكيد المعلومات المدخلة' },
-  confirm: { en: 'Confirm', ar: 'تأكيد' }
+  confirm: { en: 'Confirm', ar: 'تأكيد' },
+  upload_prompt: { en: 'Upload your document', ar: 'قم بتحميل المستند' },
+  extracting_data: { en: 'Extracting data, please wait...', ar: 'جاري استخراج البيانات، يرجى الانتظار...' },
+  invalidPassport: { en: 'Please upload a valid passport photo.', ar: 'يرجى تحميل صورة جواز سفر صالحة.' }
 };
 
 export const t = (key, lang = 'en') => {


### PR DESCRIPTION
## Summary
- validate passport uploads and reject non-passport images
- hide extracted data section for employer letter uploads
- add new translations for upload prompts and passport validation

## Testing
- `npm test --silent -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686939997188832f90f7ff785d526b14