### PR TITLE
Update personal info form and doc extraction

### DIFF
--- a/src/accountOpening/ConfirmPage_EN.js
+++ b/src/accountOpening/ConfirmPage_EN.js
@@ -55,6 +55,9 @@ const ConfirmPage_EN = ({ onNavigate, state }) => {
                         {form.documentType && (
                             <li><strong>{t('documentType', language)}:</strong> {form.documentType}</li>
                         )}
+                        {form.familyRecordNumber && (
+                            <li><strong>{t('familyRecordNumber', language)}:</strong> {form.familyRecordNumber}</li>
+                        )}
                         {form.nidDigits && (
                             <li><strong>{t('nid', language)}:</strong> {form.nidDigits.join('')}</li>
                         )}

--- a/src/accountOpening/PersonalInfoPage_EN.js
+++ b/src/accountOpening/PersonalInfoPage_EN.js
@@ -25,6 +25,7 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow, state }) => {
             dob: '',
             gender: '',
             nationality: '',
+            familyRecordNumber: '',
             nidDigits: Array(12).fill(''),
             phone: '',
             enableEmail: false,
@@ -65,6 +66,9 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow, state }) => {
         } else if (name === 'phone') {
             const digits = value.replace(/[^0-9+]/g, '');
             setForm(f => ({ ...f, phone: digits }));
+        } else if (name === 'familyRecordNumber') {
+            const digits = value.replace(/[^0-9]/g, '');
+            setForm(f => ({ ...f, familyRecordNumber: digits }));
         } else {
             setForm(f => ({ ...f, [name]: value }));
         }
@@ -124,6 +128,7 @@ const PersonalInfoPage_EN = ({ onNavigate, backPage, flow, state }) => {
                         <div className="form-group date-input-container"><input name="passportIssueDate" value={form.passportIssueDate} onChange={handleChange} type="text" className="form-input" placeholder={t('passportIssueDate', language)} onFocus={e=>e.target.type='date'} onBlur={e=>e.target.type='text'} /><CalendarIcon/></div>
                         <div className="form-group date-input-container"><input name="passportExpiryDate" value={form.passportExpiryDate} onChange={handleChange} type="text" className="form-input" placeholder={t('passportExpiryDate', language)} onFocus={e=>e.target.type='date'} onBlur={e=>e.target.type='text'} /><CalendarIcon/></div>
                         <div className="form-group"><input name="birthPlace" value={form.birthPlace} onChange={handleChange} type="text" className="form-input" placeholder={t('birthPlace', language)} /></div>
+                        <div className="form-group"><input name="familyRecordNumber" value={form.familyRecordNumber} onChange={handleChange} required type="text" className="form-input" placeholder={t('familyRecordNumber', language)} /></div>
                         {flow !== 'expat' && (
                             <div className="form-group" style={{display:'flex', gap:'5px'}}>
                                 {form.nidDigits.map((d, idx) => (

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -47,6 +47,7 @@ const translations = {
   email: { en: 'Email', ar: 'البريد الإلكتروني' },
   residenceExpiry: { en: 'Residence Expiry Date', ar: 'تاريخ انتهاء الاقامة' },
   censusCardNumber: { en: 'Census Card Number', ar: 'رقم بطاقة الحصر' },
+  familyRecordNumber: { en: 'Family Record Number', ar: 'رقم قيد العائلة' },
   addressInfoTitle: { en: 'Address Information', ar: 'معلومات العنوان' },
   country: { en: 'Country', ar: 'الدولة' },
   city: { en: 'City', ar: 'المدينة' },

--- a/src/utils/passportNidExtractors.js
+++ b/src/utils/passportNidExtractors.js
@@ -10,6 +10,7 @@ const passportSchema = {
   properties: {
     fullNameArabic: { type: 'STRING' },
     firstNameEng: { type: 'STRING' },
+    givenNameEng: { type: 'STRING' },
     midNameEng: { type: 'STRING' },
     surnameEng: { type: 'STRING' },
     passportNo: { type: 'STRING' },
@@ -26,11 +27,11 @@ const passportSchema = {
 const nidSchema = {
   type: 'OBJECT',
   properties: {
-    nationalId: { type: 'STRING' },
     familyId: { type: 'STRING' },
-    tripleName: { type: 'STRING' },
-    surname: { type: 'STRING' },
+    nationalId: { type: 'STRING' },
     sex: { type: 'STRING' },
+    birthDay: { type: 'STRING' },
+    birthMonth: { type: 'STRING' },
     birthYear: { type: 'STRING' }
   }
 };
@@ -59,7 +60,7 @@ export async function extractPassportData(file) {
   const payload = {
     contents: [{
       parts: [
-        { text: 'Extract the following fields from the passport image: Full Name (Arabic), First Name (English), Mid Name (English), Surname (English), Passport No, Date of Birth, Place of Birth, Date of Issue, Issuing Place, Sex, Nationality, and Expiry Date. Return the data in the specified JSON format.' },
+        { text: 'Extract the following fields from the passport image: Full Name (Arabic), Given Name (English), First Name (English), Mid Name (English), Surname (English), Passport No, Date of Birth, Place of Birth, Date of Issue, Issuing Place, Sex, Nationality, and Expiry Date. Return the data in the specified JSON format.' },
         { inlineData: { mimeType: file.type || "image/png", data: base64Data } }
       ]
     }],
@@ -76,7 +77,7 @@ export async function extractNIDData(file) {
   const payload = {
     contents: [{
       parts: [
-        { text: 'Extract the following fields from the NID document image: National ID (\u0627\u0644\u0631\u0642\u0645 \u0627\u0644\u0648\u0637\u0646\u064a), Family Record Number (\u0631\u0642\u0645 \u0642\u064a\u062f \u0627\u0644\u0639\u0627\u0626\u0644\u0629), Triple Name (\u0627\u0644\u0627\u0633\u0645 \u062b\u0644\u0627\u062b\u064a), Surname (\u0627\u0644\u0644\u0642\u0628), Sex (\u0627\u0644\u062c\u0646\u0633), and Year of Birth (\u0633\u0646\u0629 \u0627\u0644\u0645\u064a\u0644\u0627\u062f). Return the data in the specified JSON format.' },
+        { text: 'Extract the following fields from the NID document image: Family Record Number (\u0631\u0642\u0645 \u0642\u064a\u062f \u0627\u0644\u0639\u0627\u0626\u0644\u0629), National ID (\u0627\u0644\u0631\u0642\u0645 \u0627\u0644\u0648\u0637\u0646\u064a), Sex (\u0627\u0644\u062c\u0646\u0633), Day of Birth, Month of Birth, and Year of Birth. Return the data in the specified JSON format.' },
         { inlineData: { mimeType: file.type || "image/png", data: base64Data } }
       ]
     }],


### PR DESCRIPTION
## Summary
- add family record number label to translations
- capture family record number in personal info form
- display family record number on confirm page
- support given name on passport extraction
- extend NID extractor with birth date fields

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686a4303ce28832f92cfcc6216b9f829