### PR TITLE
Refine passport extraction and refresh handling

### DIFF
--- a/src/accountOpening/SequentialDocsPage_EN.js
+++ b/src/accountOpening/SequentialDocsPage_EN.js
@@ -63,8 +63,8 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
             personalInfo: {
               ...(d.personalInfo || {}),
               fullName: result.fullNameArabic || (d.personalInfo?.fullName || ''),
-              firstNameEn: result.firstNameEng || (d.personalInfo?.firstNameEn || ''),
-              middleNameEn: result.midNameEng || (d.personalInfo?.middleNameEn || ''),
+              firstNameEn: result.givenNameEng || (d.personalInfo?.firstNameEn || ''),
+              middleNameEn: d.personalInfo?.middleNameEn || '',
               lastNameEn: result.surnameEng || (d.personalInfo?.lastNameEn || ''),
               dob: result.dateOfBirth || (d.personalInfo?.dob || ''),
               gender: result.sex || (d.personalInfo?.gender || ''),
@@ -107,6 +107,15 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
     setError('');
   };
 
+  const handleRefresh = () => {
+    setCurrent(0);
+    setData({});
+    setImage(null);
+    setIsCopied(false);
+    setError('');
+    setIsLoading(false);
+  };
+
   const allDone = current >= DOCS.length;
   const doc = DOCS[current];
 
@@ -122,12 +131,14 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
           <span>{t('back', language)}</span>
         </button>
-        <button onClick={() => window.location.reload()} className="btn-refresh">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0114.13-3.36L23 10"></path><path d="M20.49 15a9 9 0 01-14.13 3.36L1 14"></path></svg>
-          <span>{t('refresh', language)}</span>
-        </button>
       </header>
       <main className="form-main" style={{ textAlign: 'center' }}>
+        {!allDone && (
+          <button onClick={handleRefresh} className="btn-refresh" style={{ alignSelf: 'flex-end' }}>
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0114.13-3.36L23 10"></path><path d="M20.49 15a9 9 0 01-14.13 3.36L1 14"></path></svg>
+            <span>{t('refresh', language)}</span>
+          </button>
+        )}
         {allDone ? (
           <>
             <h2 className="form-title">{t('confirmData', language)}</h2>

--- a/src/utils/docExtractor.js
+++ b/src/utils/docExtractor.js
@@ -12,8 +12,7 @@ const passportSchema = {
   type: 'OBJECT',
   properties: {
     fullNameArabic: { type: 'STRING' },
-    firstNameEng: { type: 'STRING' },
-    midNameEng: { type: 'STRING' },
+    givenNameEng: { type: 'STRING' },
     surnameEng: { type: 'STRING' },
     passportNo: { type: 'STRING' },
     dateOfBirth: { type: 'STRING' },

--- a/src/utils/passportNidExtractors.js
+++ b/src/utils/passportNidExtractors.js
@@ -9,9 +9,7 @@ const passportSchema = {
   type: 'OBJECT',
   properties: {
     fullNameArabic: { type: 'STRING' },
-    firstNameEng: { type: 'STRING' },
     givenNameEng: { type: 'STRING' },
-    midNameEng: { type: 'STRING' },
     surnameEng: { type: 'STRING' },
     passportNo: { type: 'STRING' },
     dateOfBirth: { type: 'STRING' },
@@ -60,7 +58,7 @@ export async function extractPassportData(file) {
   const payload = {
     contents: [{
       parts: [
-        { text: 'Extract the following fields from the passport image: Full Name (Arabic), Given Name (English), First Name (English), Mid Name (English), Surname (English), Passport No, Date of Birth, Place of Birth, Date of Issue, Issuing Place, Sex, Nationality, and Expiry Date. Return the data in the specified JSON format.' },
+        { text: 'Extract the following fields from the passport image: Full Name (Arabic), Given Name (English), Surname (English), Passport No, Date of Birth, Place of Birth, Date of Issue, Issuing Place, Sex, Nationality, and Expiry Date. Return the data in the specified JSON format.' },
         { inlineData: { mimeType: file.type || "image/png", data: base64Data } }
       ]
     }],


### PR DESCRIPTION
## Summary
- reset upload process without reloading the page
- show the refresh button only on document upload pages
- adjust passport extraction fields

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686a8a50b1bc832fa5d30917c734b9a0