### PR TITLE
Improve AI document mapping

### DIFF
--- a/src/accountOpening/SequentialDocsPage_EN.js
+++ b/src/accountOpening/SequentialDocsPage_EN.js
@@ -59,27 +59,43 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
       if (DOCS[current].key === 'passport') {
         result = await extractPassportData(file, provider);
         if (result) {
+          const names = (result.givenNameEng || '').trim().split(/\s+/);
+          const firstName = names[0] || '';
+          const middleName = names.slice(1).join(' ');
+          const genderVal = result.sex === 'M' ? 'male' : result.sex === 'F' ? 'female' : (result.sex || '');
           setFormData((d) => ({
             ...d,
             personalInfo: {
               ...(d.personalInfo || {}),
-              fullName: result.fullNameArabic || (d.personalInfo?.fullName || ''),
-              firstNameEn: result.givenNameEng || (d.personalInfo?.firstNameEn || ''),
-              middleNameEn: d.personalInfo?.middleNameEn || '',
-              lastNameEn: result.surnameEng || (d.personalInfo?.lastNameEn || ''),
-              dob: result.dateOfBirth || (d.personalInfo?.dob || ''),
-              gender: result.sex || (d.personalInfo?.gender || ''),
-              nationality: result.nationality || (d.personalInfo?.nationality || ''),
-              passportNumber: result.passportNo || (d.personalInfo?.passportNumber || ''),
-              passportIssueDate: result.dateOfIssue || (d.personalInfo?.passportIssueDate || ''),
-              passportExpiryDate: result.expiryDate || (d.personalInfo?.passportExpiryDate || ''),
-              birthPlace: result.placeOfBirth || (d.personalInfo?.birthPlace || ''),
+              fullName: result.fullNameArabic || d.personalInfo?.fullName || '',
+              firstNameEn: firstName || d.personalInfo?.firstNameEn || '',
+              middleNameEn: middleName || d.personalInfo?.middleNameEn || '',
+              lastNameEn: result.surnameEng || d.personalInfo?.lastNameEn || '',
+              dob: result.dateOfBirth || d.personalInfo?.dob || '',
+              gender: genderVal || d.personalInfo?.gender || '',
+              nationality: result.nationality || d.personalInfo?.nationality || '',
+              passportNumber: result.passportNo || d.personalInfo?.passportNumber || '',
+              passportIssueDate: result.dateOfIssue || d.personalInfo?.passportIssueDate || '',
+              passportExpiryDate: result.expiryDate || d.personalInfo?.passportExpiryDate || '',
+              birthPlace: result.placeOfBirth || d.personalInfo?.birthPlace || '',
             },
             passportData: result,
           }));
         }
       } else if (DOCS[current].key === 'nationalId') {
         result = await extractNIDData(file, provider);
+        if (result) {
+          const nidDigits = result.nationalId ? result.nationalId.replace(/\D/g, '').slice(0, 12).split('') : [];
+          setFormData((d) => ({
+            ...d,
+            personalInfo: {
+              ...(d.personalInfo || {}),
+              familyRecordNumber: result.familyId || d.personalInfo?.familyRecordNumber || '',
+              nidDigits: nidDigits.length ? nidDigits : d.personalInfo?.nidDigits || Array(12).fill(''),
+            },
+            nidData: result,
+          }));
+        }
       } else {
         await uploadDocument(file, DOCS[current].key);
         result = { uploaded: true };
@@ -127,9 +143,9 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
         <div style={{ display: 'flex', gap: '30px', alignItems: 'center' }}>
           <ThemeSwitcher />
           <LanguageSwitcher />
-          <label style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'white' }}>
+          <label className="api-provider-label" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             {t('apiProvider', language)}:
-            <select value={provider} onChange={(e) => setProvider(e.target.value)}>
+            <select value={provider} onChange={(e) => setProvider(e.target.value)} className="api-provider-select">
               <option value="gemini">{t('gemini', language)}</option>
               <option value="chatgpt">{t('chatgpt', language)}</option>
             </select>

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -295,7 +295,28 @@ const GlobalStyles = () => (
     .btn-next:hover { background-color: var(--primary-dark); box-shadow: 0 8px 20px rgba(62, 138, 150, 0.4); }
     .btn-next:disabled { background-color: #999; cursor: not-allowed; box-shadow: none; }
     .btn-back { background: none; border: none; color: #fff; font-size: 1rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; gap: 5px; }
-    .btn-refresh { background: none; border: none; color: #fff; font-size: 1rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; gap: 5px; }
+    .btn-refresh {
+        background: none;
+        border: none;
+        color: var(--text-color-light);
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 5px;
+    }
+
+    .api-provider-label {
+        color: var(--text-color-light);
+    }
+    .api-provider-select {
+        padding: 6px 12px;
+        border-radius: 6px;
+        border: 1px solid var(--primary-color);
+        background-color: var(--form-input-bg);
+        color: var(--form-input-text);
+    }
     
     /* ---=== Form Styles ===--- */
     .form-container { width: 100%; max-width: 600px; }


### PR DESCRIPTION
## Summary
- style AI Provider selector and Refresh button using theme variables
- map passport data to personal info fields
- parse given name into first and middle names and set gender
- update form with National ID info when extracted

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a986c59d0832fa19a11a6168f12ca