### PR TITLE
Improve AI provider toggle and theme-based refresh button

### DIFF
--- a/src/accountOpening/SequentialDocsPage_EN.js
+++ b/src/accountOpening/SequentialDocsPage_EN.js
@@ -5,6 +5,7 @@ import { uploadDocument } from '../utils/fileUploader';
 import { t } from '../i18n';
 import ThemeSwitcher from '../common/ThemeSwitcher';
 import LanguageSwitcher from '../common/LanguageSwitcher';
+import AIProviderSwitcher from '../common/AIProviderSwitcher';
 import Footer from '../common/Footer';
 import { UploadIcon } from '../common/Icons';
 import { LOGO_WHITE } from '../assets/imagePaths';
@@ -145,10 +146,7 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
           <LanguageSwitcher />
           <label className="api-provider-label" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             {t('apiProvider', language)}:
-            <select value={provider} onChange={(e) => setProvider(e.target.value)} className="api-provider-select">
-              <option value="gemini">{t('gemini', language)}</option>
-              <option value="chatgpt">{t('chatgpt', language)}</option>
-            </select>
+            <AIProviderSwitcher provider={provider} onChange={setProvider} />
           </label>
         </div>
         <button onClick={() => onNavigate(backPage)} className="btn-back">

--- a/src/common/AIProviderSwitcher.js
+++ b/src/common/AIProviderSwitcher.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useLanguage } from '../contexts/LanguageContext';
+import { t } from '../i18n';
+
+const AIProviderSwitcher = ({ provider, onChange }) => {
+  const { language } = useLanguage();
+  return (
+    <div className="language-switcher ai-provider-switcher">
+      <span
+        className={provider === 'gemini' ? 'active' : ''}
+        onClick={() => onChange('gemini')}
+      >
+        {t('gemini', language)}
+      </span>
+      <span
+        className={provider === 'chatgpt' ? 'active' : ''}
+        onClick={() => onChange('chatgpt')}
+      >
+        {t('chatgpt', language)}
+      </span>
+    </div>
+  );
+};
+
+export default AIProviderSwitcher;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -296,7 +296,7 @@ const GlobalStyles = () => (
     .btn-next:disabled { background-color: #999; cursor: not-allowed; box-shadow: none; }
     .btn-back { background: none; border: none; color: #fff; font-size: 1rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; gap: 5px; }
     .btn-refresh {
-        background: none;
+        background-color: var(--primary-color);
         border: none;
         color: var(--text-color-light);
         font-size: 1rem;
@@ -305,17 +305,24 @@ const GlobalStyles = () => (
         display: flex;
         align-items: center;
         gap: 5px;
+        padding: 8px 16px;
+        border-radius: 8px;
+        box-shadow: 0 2px 6px var(--shadow-color);
+        transition: background-color 0.3s ease, transform 0.3s ease;
+    }
+    .btn-refresh:hover {
+        background-color: var(--primary-dark);
+        transform: scale(1.05);
     }
 
     .api-provider-label {
         color: var(--text-color-light);
+        display: flex;
+        align-items: center;
+        gap: 8px;
     }
-    .api-provider-select {
-        padding: 6px 12px;
-        border-radius: 6px;
-        border: 1px solid var(--primary-color);
-        background-color: var(--form-input-bg);
-        color: var(--form-input-text);
+    .ai-provider-switcher span {
+        cursor: pointer;
     }
     
     /* ---=== Form Styles ===--- */


### PR DESCRIPTION
## Summary
- create `AIProviderSwitcher` component styled like `LanguageSwitcher`
- integrate new switcher in `SequentialDocsPage_EN`
- restyle refresh button to match the current theme

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686a9c113fbc832f8345d0deb35eb3ff