### PR TITLE
Remove AI Provider label and switch default to ChatGPT

### DIFF
--- a/src/accountOpening/SequentialDocsPage_EN.js
+++ b/src/accountOpening/SequentialDocsPage_EN.js
@@ -29,7 +29,7 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
   const [image, setImage] = useState(null);
   const [isCopied, setIsCopied] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
-  const [provider, setProvider] = useState('gemini');
+  const [provider, setProvider] = useState('chatgpt');
   const fileInputRef = useRef(null);
 
   const handleDragEvents = (e) => {
@@ -144,10 +144,7 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
         <div className="header-switchers" style={{ alignItems: 'center' }}>
           <ThemeSwitcher />
           <LanguageSwitcher />
-          <label className="api-provider-label" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            {t('apiProvider', language)}:
-            <AIProviderSwitcher provider={provider} onChange={setProvider} />
-          </label>
+          <AIProviderSwitcher provider={provider} onChange={setProvider} />
         </div>
         <button onClick={() => onNavigate(backPage)} className="btn-back">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -85,7 +85,6 @@ const translations = {
   exportPdf: { en: 'Export PDF', ar: 'تصدير' },
   registerEServices: { en: 'Register for E-Services', ar: 'تسجيل في خدمات الكترونية' },
   refresh: { en: 'Refresh', ar: 'تحديث' },
-  apiProvider: { en: 'AI Provider', ar: 'مُقدم الذكاء الاصطناعي' },
   gemini: { en: 'Gemini', ar: 'Gemini' },
   chatgpt: { en: 'ChatGPT', ar: 'شات جي بي تي' }
 };

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -321,12 +321,6 @@ const GlobalStyles = () => (
         transform: scale(1.05);
     }
 
-    .api-provider-label {
-        color: var(--text-color-light);
-        display: flex;
-        align-items: center;
-        gap: 8px;
-    }
     .ai-provider-switcher span {
         cursor: pointer;
     }


### PR DESCRIPTION
## Summary
- remove unused i18n key for the provider label
- default to ChatGPT in SequentialDocsPage
- drop the label text and clean related styling

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa6651d1c832fb4626010230550a4