### PR TITLE
Add document caching and UX improvements

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,6 +12,8 @@ app.use(cors());
 app.use(express.json());
 
 let cachedForm = {};
+let cachedUploads = {};
+let cachedExtracted = {};
 
 app.post('/api/cache-form', (req, res) => {
   cachedForm = req.body || {};
@@ -23,8 +25,27 @@ app.get('/api/cache-form', (req, res) => {
 });
 
 app.post('/api/cache-upload', upload.single('file'), (req, res) => {
-  // File saved in uploads folder; you could process or move as needed
+  const docType = req.body.docType;
+  if (req.file && docType) {
+    cachedUploads[docType] = req.file.path;
+  }
   res.json({ uploaded: true });
+});
+
+app.get('/api/cache-upload/:docType', (req, res) => {
+  res.json({ path: cachedUploads[req.params.docType] });
+});
+
+app.post('/api/cache-extracted', (req, res) => {
+  const { docType, data } = req.body || {};
+  if (docType) {
+    cachedExtracted[docType] = data;
+  }
+  res.json({ success: true });
+});
+
+app.get('/api/cache-extracted/:docType', (req, res) => {
+  res.json(cachedExtracted[req.params.docType] || {});
 });
 
 app.listen(PORT, () => {

--- a/src/accountOpening/SequentialDocsPage_EN.js
+++ b/src/accountOpening/SequentialDocsPage_EN.js
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react';
 import { extractDocumentData } from '../utils/docExtractor';
 import { extractPassportData, extractNIDData } from '../utils/passportNidExtractors';
 import { uploadDocument } from '../utils/fileUploader';
+import { cacheExtractedData } from '../utils/dataCacher';
 import { t } from '../i18n';
 import ThemeSwitcher from '../common/ThemeSwitcher';
 import LanguageSwitcher from '../common/LanguageSwitcher';
@@ -59,6 +60,7 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
     setError('');
     try {
       let result;
+      await uploadDocument(file, DOCS[current].key);
       if (DOCS[current].key === 'passport') {
         result = await extractPassportData(file, provider);
         if (result) {
@@ -108,10 +110,10 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
           });
         }
       } else {
-        await uploadDocument(file, DOCS[current].key);
         result = { uploaded: true };
       }
       setData((d) => ({ ...d, [DOCS[current].key]: result }));
+      await cacheExtractedData(DOCS[current].key, result);
     } catch (e) {
       console.error(e);
       setError('Failed to extract data');
@@ -151,8 +153,8 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
         <img src={LOGO_WHITE} alt="Bank Logo" className="logo" />
         <div className="header-switchers" style={{ alignItems: 'center' }}>
           <ThemeSwitcher />
-          <LanguageSwitcher />
           <AIProviderSwitcher provider={provider} onChange={setProvider} />
+          <LanguageSwitcher />
         </div>
         <button onClick={() => onNavigate(backPage)} className="btn-back">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
@@ -201,6 +203,14 @@ const SequentialDocsPage_EN = ({ onNavigate, backPage, nextPage }) => {
               <div className="result-container">
                 <div className="image-preview-box">
                   <img src={image} alt="preview" />
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current.click()}
+                    className="btn-change"
+                    style={{ marginTop: '10px' }}
+                  >
+                    {t('change_document', language)}
+                  </button>
                 </div>
                 {doc.key !== 'letter' && (
                   <div className="data-result-box">

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -86,7 +86,8 @@ const translations = {
   registerEServices: { en: 'Register for E-Services', ar: 'تسجيل في خدمات الكترونية' },
   refresh: { en: 'Refresh', ar: 'تحديث' },
   gemini: { en: 'Gemini', ar: 'Gemini' },
-  chatgpt: { en: 'ChatGPT', ar: 'شات جي بي تي' }
+  chatgpt: { en: 'ChatGPT', ar: 'شات جي بي تي' },
+  change_document: { en: 'Change Document', ar: 'تغيير المستند' }
 };
 
 export const t = (key, lang = 'en') => {

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -320,6 +320,22 @@ const GlobalStyles = () => (
         background-color: var(--primary-dark);
         transform: scale(1.05);
     }
+    .btn-change {
+        background-color: var(--secondary-color);
+        border: none;
+        color: var(--text-color-dark);
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        padding: 8px 16px;
+        border-radius: 8px;
+        box-shadow: 0 2px 6px var(--shadow-color);
+        transition: background-color 0.3s ease, transform 0.3s ease;
+    }
+    .btn-change:hover {
+        background-color: var(--secondary-dark);
+        transform: scale(1.05);
+    }
 
     .ai-provider-switcher span {
         cursor: pointer;

--- a/src/utils/dataCacher.js
+++ b/src/utils/dataCacher.js
@@ -1,0 +1,11 @@
+export async function cacheExtractedData(docType, data) {
+  const resp = await fetch('/api/cache-extracted', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ docType, data }),
+  });
+  if (!resp.ok) {
+    throw new Error('Cache failed');
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- swap AI provider switcher position with language switcher
- allow changing uploaded document
- cache uploaded files and extracted data on the server

## Testing
- `npm install`
- `CI=true npm test --silent -- --watchAll=false` *(no tests found)*


------
https://chatgpt.com/codex/tasks/task_e_686ac5089fe4832fa7c9ea14654781fe