### PR TITLE
Improve ChatGPT handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create a `.env` file in the project root based on `.env.example` and provide you
 cp .env.example .env
 ```
 
-Edit `.env` and replace the placeholders with your actual keys. `REACT_APP_GEMINI_API_KEY` is used for Google Gemini requests and `REACT_APP_OPENAI_API_KEY` for ChatGPT requests.
+Edit `.env` and replace the placeholders with your actual keys. `REACT_APP_GEMINI_API_KEY` is used for Google Gemini requests and `REACT_APP_OPENAI_API_KEY` for ChatGPT requests. Ensure the keys are on a single line and keep them private.
 `REACT_APP_API_BASE_URL` should point to the Express server URL (default `http://localhost:5000`).
 
 ## Running the server
@@ -19,4 +19,14 @@ An Express server is included for caching uploaded files and form data. Start it
 npm install
 node server.js
 ```
+If you run the server on a different port (e.g. 3001), update `REACT_APP_API_BASE_URL` in your `.env` to match:
+
+```bash
+REACT_APP_API_BASE_URL=http://localhost:3001
+```
+
+The ChatGPT provider relies on a working internet connection. If requests fail with
+"Failed to fetch", ensure that your environment allows outbound HTTPS requests to
+`api.openai.com` and that your API key is valid.
+
 

--- a/src/utils/docExtractor.js
+++ b/src/utils/docExtractor.js
@@ -69,6 +69,9 @@ async function callGemini(payload) {
 
 async function callChatGPT(prompt, base64Data, mimeType) {
   const apiKey = process.env.REACT_APP_OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('Missing OpenAI API key');
+  }
   const resp = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -91,6 +94,10 @@ async function callChatGPT(prompt, base64Data, mimeType) {
       response_format: { type: 'json_object' },
     }),
   });
+
+  if (!resp.ok) {
+    throw new Error(`OpenAI request failed: ${resp.status}`);
+  }
 
   const result = await resp.json();
   if (result.choices && result.choices[0].message && result.choices[0].message.content) {

--- a/src/utils/passportNidExtractors.js
+++ b/src/utils/passportNidExtractors.js
@@ -55,6 +55,9 @@ async function callGemini(payload) {
 
 async function callChatGPT(prompt, base64Data, mimeType) {
   const apiKey = process.env.REACT_APP_OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('Missing OpenAI API key');
+  }
   const resp = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -77,6 +80,11 @@ async function callChatGPT(prompt, base64Data, mimeType) {
       response_format: { type: 'json_object' }
     }),
   });
+
+  if (!resp.ok) {
+    throw new Error(`OpenAI request failed: ${resp.status}`);
+  }
+
   const result = await resp.json();
   if (result.choices && result.choices[0].message && result.choices[0].message.content) {
     try {


### PR DESCRIPTION
## Summary
- add explicit error checks when calling ChatGPT APIs
- document that ChatGPT needs an internet connection and a valid API key

## Testing
- `npm install --silent`
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae09ea380832f9c017e9f6546c08c