### PR TITLE
Fix pdf export memory issue

### DIFF
--- a/src/accountOpening/ConfirmPage_EN.js
+++ b/src/accountOpening/ConfirmPage_EN.js
@@ -43,7 +43,12 @@ const ConfirmPage_EN = ({ onNavigate, state }) => {
         const doc = new jsPDF();
         const fontResp = await fetch(arabicFont);
         const fontData = await fontResp.arrayBuffer();
-        const fontBase64 = btoa(String.fromCharCode(...new Uint8Array(fontData)));
+        let binary = '';
+        const bytes = new Uint8Array(fontData);
+        for (let i = 0; i < bytes.length; i += 1) {
+            binary += String.fromCharCode(bytes[i]);
+        }
+        const fontBase64 = btoa(binary);
         doc.addFileToVFS('NotoSansArabic.ttf', fontBase64);
         doc.addFont('NotoSansArabic.ttf', 'NotoSansArabic', 'normal');
         doc.setFont('NotoSansArabic');


### PR DESCRIPTION
## Summary
- avoid using spread operator for large font data when generating PDF

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686bc6dac194832f84c721beffa3bd99