### PR TITLE
Add configurable API endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 REACT_APP_GEMINI_API_KEY=AIzaSyCO77GJbCQM5fmc877iGUKhBKTWIaMy6zo
 REACT_APP_OPENAI_API_KEY=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
 REACT_APP_API_BASE_URL=http://localhost:7003
+REACT_APP_OPENAI_URL=https://api.openai.com/v1/chat/completions
+REACT_APP_GEMINI_URL=https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ cp .env.example .env
 ```
 
 Edit `.env` and replace the placeholders with your actual keys. `REACT_APP_GEMINI_API_KEY` is used for Google Gemini requests and `REACT_APP_OPENAI_API_KEY` for ChatGPT requests. Ensure the keys are on a single line and keep them private.
-`REACT_APP_API_BASE_URL` should point to the Express server URL (default `http://localhost:7003`).
+`REACT_APP_API_BASE_URL` should point to the Express server URL (default `http://localhost:7003`). `REACT_APP_OPENAI_URL` and `REACT_APP_GEMINI_URL` allow overriding the default API endpoints if needed.
 
 ## Running the server
 

--- a/server.js
+++ b/server.js
@@ -80,8 +80,10 @@ app.post('/api/chatgpt', async (req, res) => {
     logMessage('Missing OpenAI API key');
     return res.status(400).json({ error: 'Missing API key' });
   }
+  const openaiUrl = process.env.REACT_APP_OPENAI_URL ||
+    'https://api.openai.com/v1/chat/completions';
   try {
-    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+    const resp = await fetch(openaiUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/utils/docExtractor.js
+++ b/src/utils/docExtractor.js
@@ -50,7 +50,9 @@ const DOC_CONFIGS = {
 
 async function callGemini(payload) {
   const apiKey = process.env.REACT_APP_GEMINI_API_KEY;
-  const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
+  const geminiUrl = process.env.REACT_APP_GEMINI_URL ||
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+  const apiUrl = `${geminiUrl}?key=${apiKey}`;
 
   const resp = await fetch(apiUrl, {
     method: 'POST',

--- a/src/utils/passportNidExtractors.js
+++ b/src/utils/passportNidExtractors.js
@@ -39,7 +39,9 @@ const nidSchema = {
 
 async function callGemini(payload) {
   const apiKey = process.env.REACT_APP_GEMINI_API_KEY;
-  const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
+  const geminiUrl = process.env.REACT_APP_GEMINI_URL ||
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+  const apiUrl = `${geminiUrl}?key=${apiKey}`;
   const resp = await fetch(apiUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- support configurable ChatGPT and Gemini API URLs via env variables
- document new variables in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be4f9d6a4832fb8afac0e507c9267