### PR TITLE
Add AI module and response logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The ChatGPT provider relies on a working internet connection. If requests fail w
 ## Logs
 
 All errors and ChatGPT responses are written to daily log files under the `logs/`
-directory. These files are created automatically when the server runs.
+directory. Each AI reply is also stored in files prefixed `ai_respo_` followed by
+the date (e.g. `logs/ai_respo_2024-05-30.log`). These files are created
+automatically when the server runs.
 
 

--- a/ai.js
+++ b/ai.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+
+const logsDir = path.join(__dirname, 'logs');
+if (!fs.existsSync(logsDir)) {
+  fs.mkdirSync(logsDir);
+}
+
+function logAIResponse(message) {
+  const file = path.join(
+    logsDir,
+    `ai_respo_${new Date().toISOString().split('T')[0]}.log`
+  );
+  const entry = `[${new Date().toISOString()}] ${message}\n`;
+  fs.appendFile(file, entry, err => {
+    if (err) console.error('AI log error:', err);
+  });
+}
+
+async function callChatGPT(prompt, base64Data, mimeType) {
+  const apiKey = process.env.REACT_APP_OPENAI_API_KEY;
+  if (!apiKey) {
+    logAIResponse('Missing OpenAI API key');
+    throw new Error('Missing API key');
+  }
+
+  const openaiUrl =
+    process.env.REACT_APP_OPENAI_URL ||
+    'https://api.openai.com/v1/chat/completions';
+
+  try {
+    const resp = await fetch(openaiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages: [
+          { role: 'system', content: 'You extract data from images and return JSON.' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: `${prompt} Only return valid JSON.` },
+              { type: 'image_url', image_url: { url: `data:${mimeType};base64,${base64Data}` } },
+            ],
+          },
+        ],
+        max_tokens: 1000,
+        response_format: { type: 'json_object' },
+      }),
+    });
+
+    const data = await resp.json();
+    logAIResponse(`CHATGPT_RESPONSE ${JSON.stringify(data)}`);
+
+    if (!resp.ok) {
+      throw new Error(`OpenAI request failed: ${resp.status}`);
+    }
+
+    return data;
+  } catch (err) {
+    logAIResponse(`CHATGPT_ERROR ${err.message}`);
+    throw err;
+  }
+}
+
+module.exports = {
+  callChatGPT,
+  logAIResponse,
+};

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const multer = require('multer');
 const cors = require('cors');
 const path = require('path');
 const fs = require('fs');
+const { callChatGPT } = require('./ai');
 
 const logsDir = path.join(__dirname, 'logs');
 if (!fs.existsSync(logsDir)) {
@@ -75,43 +76,14 @@ app.post('/api/log', (req, res) => {
 
 app.post('/api/chatgpt', async (req, res) => {
   const { prompt, base64Data, mimeType } = req.body || {};
-  const apiKey = process.env.REACT_APP_OPENAI_API_KEY;
-  if (!apiKey) {
-    logMessage('Missing OpenAI API key');
-    return res.status(400).json({ error: 'Missing API key' });
-  }
-  const openaiUrl = process.env.REACT_APP_OPENAI_URL ||
-    'https://api.openai.com/v1/chat/completions';
   try {
-    const resp = await fetch(openaiUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o',
-        messages: [
-          { role: 'system', content: 'You extract data from images and return JSON.' },
-          {
-            role: 'user',
-            content: [
-              { type: 'text', text: `${prompt} Only return valid JSON.` },
-              { type: 'image_url', image_url: { url: `data:${mimeType};base64,${base64Data}` } },
-            ],
-          },
-        ],
-        max_tokens: 1000,
-        response_format: { type: 'json_object' },
-      }),
-    });
-
-    const data = await resp.json();
+    const data = await callChatGPT(prompt, base64Data, mimeType);
     logMessage(`CHATGPT_RESPONSE ${JSON.stringify(data)}`);
-    res.status(resp.ok ? 200 : resp.status).json(data);
+    res.json(data);
   } catch (e) {
     logMessage(`CHATGPT_ERROR ${e.message}`);
-    res.status(500).json({ error: 'OpenAI request failed' });
+    const status = e.message === 'Missing API key' ? 400 : 500;
+    res.status(status).json({ error: e.message });
   }
 });
 


### PR DESCRIPTION
## Summary
- add dedicated `ai.js` module to handle ChatGPT requests
- log AI responses to `logs/ai_respo_DATE.log`
- refactor server to use the new module
- document new log file in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686bec2940c4832f85341e6f925921ad