### PR TITLE
Fix missing API key and large request errors

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,6 +5,9 @@ const path = require('path');
 const fs = require('fs');
 const { callChatGPT } = require('./ai');
 
+// Load environment variables from the .env file if present
+require('dotenv').config();
+
 const logsDir = path.join(__dirname, 'logs');
 if (!fs.existsSync(logsDir)) {
   fs.mkdirSync(logsDir);
@@ -27,7 +30,8 @@ const HTTP_PORT = process.env.PORT || 7003;
 const HTTPS_PORT = process.env.HTTPS_PORT || 7103;
 
 app.use(cors());
-app.use(express.json({ limit: '10mb' }));
+// Allow slightly larger payloads for image data
+app.use(express.json({ limit: '20mb' }));
 
 let cachedForm = {};
 let cachedUploads = {};


### PR DESCRIPTION
## Summary
- load `.env` variables in `server.js`
- increase JSON body limit to 20 MB for large image payloads

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686bf2ea21d4832f9aa8a5a39b31b370