### PR TITLE
Add validation endpoints and update service type handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -522,6 +522,76 @@ app.post('/api/add-document', upload.single('file'), async (req, res) => {
   }
 });
 
+// Update selected service type for an existing customer
+app.post('/api/service-type', async (req, res) => {
+  const { reference, nid, serviceType } = req.body || {};
+  if (!serviceType || (!reference && !nid)) {
+    return res.status(400).json({ error: 'missing_parameters' });
+  }
+  try {
+    let personal;
+    if (reference) {
+      personal = await pool.query('SELECT id FROM personal_info WHERE reference_number=$1', [reference]);
+    } else {
+      personal = await pool.query('SELECT id FROM personal_info WHERE national_id=$1 ORDER BY created_at DESC LIMIT 1', [nid]);
+    }
+    if (personal.rows.length === 0) return res.status(404).json({ error: 'not_found' });
+    const pid = personal.rows[0].id;
+    await pool.query('UPDATE personal_info SET service_type=$1 WHERE id=$2', [serviceType, pid]);
+    logActivity(`SERVICE_TYPE_UPDATE ${pid}`);
+    res.json({ success: true });
+  } catch (e) {
+    logError(`SERVICE_TYPE_ERROR ${e.message}`);
+    res.status(500).json({ error: 'server_error' });
+  }
+});
+
+// Approve or reject address information
+app.post('/api/address-validation', async (req, res) => {
+  const { reference, nid, approved, adminName } = req.body || {};
+  if (!reference && !nid) return res.status(400).json({ error: 'missing_identifier' });
+  try {
+    let personal;
+    if (reference) {
+      personal = await pool.query('SELECT id FROM personal_info WHERE reference_number=$1', [reference]);
+    } else {
+      personal = await pool.query('SELECT id FROM personal_info WHERE national_id=$1 ORDER BY created_at DESC LIMIT 1', [nid]);
+    }
+    if (personal.rows.length === 0) return res.status(404).json({ error: 'not_found' });
+    const pid = personal.rows[0].id;
+    const adminIp = (req.headers['x-forwarded-for'] || req.ip || '').split(',')[0];
+    await pool.query('UPDATE address_info SET confirmed_by_admin=$1 WHERE personal_id=$2', [approved, pid]);
+    logActivity(`ADDRESS_VALIDATE ${pid} ${approved} ${adminName || ''} ${adminIp}`);
+    res.json({ success: true });
+  } catch (e) {
+    logError(`ADDRESS_VALIDATE_ERROR ${e.message}`);
+    res.status(500).json({ error: 'server_error' });
+  }
+});
+
+// Approve or reject work and income information
+app.post('/api/work-validation', async (req, res) => {
+  const { reference, nid, approved, adminName } = req.body || {};
+  if (!reference && !nid) return res.status(400).json({ error: 'missing_identifier' });
+  try {
+    let personal;
+    if (reference) {
+      personal = await pool.query('SELECT id FROM personal_info WHERE reference_number=$1', [reference]);
+    } else {
+      personal = await pool.query('SELECT id FROM personal_info WHERE national_id=$1 ORDER BY created_at DESC LIMIT 1', [nid]);
+    }
+    if (personal.rows.length === 0) return res.status(404).json({ error: 'not_found' });
+    const pid = personal.rows[0].id;
+    const adminIp = (req.headers['x-forwarded-for'] || req.ip || '').split(',')[0];
+    await pool.query('UPDATE work_income_info SET confirmed_by_admin=$1 WHERE personal_id=$2', [approved, pid]);
+    logActivity(`WORK_VALIDATE ${pid} ${approved} ${adminName || ''} ${adminIp}`);
+    res.json({ success: true });
+  } catch (e) {
+    logError(`WORK_VALIDATE_ERROR ${e.message}`);
+    res.status(500).json({ error: 'server_error' });
+  }
+});
+
 app.use((err, req, res, next) => {
   logError(`ERROR ${err.message}`);
   res.status(500).json({ error: 'Server error' });

--- a/src/accountOpening/SelectUserPage_EN.js
+++ b/src/accountOpening/SelectUserPage_EN.js
@@ -9,6 +9,8 @@ import { t } from '../i18n';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useFormData } from '../contexts/FormContext';
 
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '';
+
 const SelectUserPage_EN = ({ onNavigate }) => {
   useEffect(() => {
     const card = document.querySelector('.tilt-effect');
@@ -33,10 +35,21 @@ const SelectUserPage_EN = ({ onNavigate }) => {
   }, []);
 
   const { language } = useLanguage();
-  const { setFormData } = useFormData();
+  const { formData, setFormData } = useFormData();
 
-  const selectService = (type, page) => {
+  const selectService = async (type, page) => {
     setFormData(d => ({ ...d, serviceType: type }));
+    const reference = formData.personalInfo?.referenceNumber || formData.personalInfo?.reference_number;
+    const nid = (formData.personalInfo?.nidDigits || []).join('');
+    if (reference) {
+      try {
+        await fetch(`${API_BASE_URL}/api/service-type`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reference, nid, serviceType: type })
+        });
+      } catch (e) { console.error(e); }
+    }
     onNavigate(page);
   };
 

--- a/src/completeAccount/ReviewAddressInfoPage_EN.js
+++ b/src/completeAccount/ReviewAddressInfoPage_EN.js
@@ -7,12 +7,14 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { t } from '../i18n';
 
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '';
+const ADMIN_NAME = process.env.REACT_APP_ADMIN_NAME || 'Admin';
 
 const ReviewAddressInfoPage_EN = ({ onNavigate, state }) => {
   const { language } = useLanguage();
   const [info, setInfo] = useState(state?.personalInfo || {});
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState({});
+  const [approved, setApproved] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -27,6 +29,7 @@ const ReviewAddressInfoPage_EN = ({ onNavigate, state }) => {
             if (data) {
               setInfo(data);
               setForm(data);
+              setApproved(!!data.confirmed_by_admin);
             }
           }
         } catch (e) { console.error(e); }
@@ -37,6 +40,7 @@ const ReviewAddressInfoPage_EN = ({ onNavigate, state }) => {
 
   useEffect(() => {
     if (!editing) setForm(info);
+    setApproved(!!info.confirmed_by_admin);
   }, [info]);
 
   const renderList = (obj) => (
@@ -62,6 +66,20 @@ const ReviewAddressInfoPage_EN = ({ onNavigate, state }) => {
       });
       setInfo(form);
       setEditing(false);
+    } catch (e) { console.error(e); }
+  };
+
+  const toggleApproved = async () => {
+    const ref = state?.personalInfo?.reference_number;
+    if (!ref) return;
+    const newVal = !approved;
+    setApproved(newVal);
+    try {
+      await fetch(`${API_BASE_URL}/api/address-validation`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reference: ref, approved: newVal, adminName: ADMIN_NAME })
+      });
     } catch (e) { console.error(e); }
   };
 
@@ -93,7 +111,11 @@ const ReviewAddressInfoPage_EN = ({ onNavigate, state }) => {
             <button type="button" className="btn-next" onClick={() => setEditing(true)}>{t('unlock', language)}</button>
           </>
         )}
-        <div className="form-actions">
+        <div className="form-actions" style={{display:'flex',alignItems:'center',gap:'10px'}}>
+          <label style={{display:'flex',alignItems:'center',gap:'5px'}}>
+            <input type="checkbox" checked={approved} onChange={toggleApproved} />
+            {t('valid', language)}
+          </label>
           <button className="btn-next" onClick={() => onNavigate('eServicesReg', state)}>
             {t('approve', language)}
           </button>

--- a/src/completeAccount/ReviewWorkInfoPage_EN.js
+++ b/src/completeAccount/ReviewWorkInfoPage_EN.js
@@ -7,6 +7,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { t } from '../i18n';
 
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '';
+const ADMIN_NAME = process.env.REACT_APP_ADMIN_NAME || 'Admin';
 
 const ReviewWorkInfoPage_EN = ({ onNavigate, state }) => {
   const { language } = useLanguage();
@@ -14,6 +15,7 @@ const ReviewWorkInfoPage_EN = ({ onNavigate, state }) => {
   const [valid, setValid] = useState({});
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState({});
+  const [approved, setApproved] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -26,6 +28,7 @@ const ReviewWorkInfoPage_EN = ({ onNavigate, state }) => {
           if (data) {
             setWork(data);
             setForm(data);
+            setApproved(!!data.confirmed_by_admin);
           }
         }
       } catch (e) { console.error(e); }
@@ -40,6 +43,7 @@ const ReviewWorkInfoPage_EN = ({ onNavigate, state }) => {
     });
     setValid(init);
     if (!editing) setForm(work);
+    setApproved(!!work.confirmed_by_admin);
   }, [work]);
 
   const toggleValid = (key) => {
@@ -57,6 +61,20 @@ const ReviewWorkInfoPage_EN = ({ onNavigate, state }) => {
       });
       setWork(form);
       setEditing(false);
+    } catch (e) { console.error(e); }
+  };
+
+  const toggleApproved = async () => {
+    const ref = state?.personalInfo?.reference_number;
+    if (!ref) return;
+    const newVal = !approved;
+    setApproved(newVal);
+    try {
+      await fetch(`${API_BASE_URL}/api/work-validation`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reference: ref, approved: newVal, adminName: ADMIN_NAME })
+      });
     } catch (e) { console.error(e); }
   };
 
@@ -112,7 +130,11 @@ const ReviewWorkInfoPage_EN = ({ onNavigate, state }) => {
             <button type="button" className="btn-next" onClick={() => setEditing(true)}>{t('unlock', language)}</button>
           </>
         )}
-        <div className="form-actions">
+        <div className="form-actions" style={{display:'flex',alignItems:'center',gap:'10px'}}>
+          <label style={{display:'flex',alignItems:'center',gap:'5px'}}>
+            <input type="checkbox" checked={approved} onChange={toggleApproved} />
+            {t('valid', language)}
+          </label>
           <button className="btn-next" onClick={() => onNavigate('reviewAddressInfo', state)}>{t('approve', language)}</button>
         </div>
       </main>


### PR DESCRIPTION
## Summary
- add API endpoints to update service type and validate address/work information
- allow admins to mark address and work info as valid in review pages
- update Select Service Type page to persist choice on the server

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`
- `node server.js` *(launched then exited)*

------
https://chatgpt.com/codex/tasks/task_e_68751de359b0832f9699bffb66ca9261